### PR TITLE
fix(deps): refresh audited transitive dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,21 +4,10 @@
 - Save created plans **ALWAYS** in `docs/plans` folder. Save them with the pattern: 'yyyy-mm-dd_short-description'
 
 ### Frontend Architecture
-- Frontend typescript code is stored under: `frontend`. 
+
 - Put large screen-specific features under `frontend/src/features/<feature-name>/`.
 - Keep `frontend/src/components/` for shared, reusable UI primitives rather than full-screen controllers.
 - Keep route/session entry components thin: compose feature hooks and feature components instead of combining protocol, media, store, and UI logic in one file.
-
-### Frontend Technology
-- typescript single page application using react and tan-stack-start 
-
-### Backend
-- Backend rust code is stored under: `backend` 
-- Managing auth, users and roles. But not limited to it for future purposes
-
-### Infra
-- Infrastructure can be found under: `infrastructure` 
-- We use LiveKit as a server to manage audio, video and rooms. <D-s>
 
 ### PRs
 - before publishing a PR, review your changes again and fix issues proactively. Ask for clarification if in doubt.
@@ -34,4 +23,4 @@ Use `pnpm --filter frontend clients:start -- Alice Bob Carol` (or equivalent mul
 ## What NOT to do
 
 ### Rust
-- do NOT use 'unwrap' in production code<D-s>
+- do NOT use 'unwrap' in production code

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1672,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/docs/plans/2026-05-31_h3-v2-ga-upgrade.md
+++ b/docs/plans/2026-05-31_h3-v2-ga-upgrade.md
@@ -1,0 +1,13 @@
+# h3 v2 GA Upgrade Follow-up
+
+## Summary
+Track removal of the `h3-v2` `npm:h3@2.0.1-rc.20` pin once TanStack Start and the app's SSR/LiveKit pages are validated against h3 v2 GA.
+
+## Tracking
+Tracking ID: H3-V2-GA-2026-05-31
+
+## Acceptance Criteria
+- Upstream h3 v2 GA is available.
+- `@tanstack/start-server-core` or its consumers are confirmed compatible.
+- Frontend typecheck, tests, and end-to-end checks pass after unpinning.
+- The `h3-v2` override can be removed from `package.json`.

--- a/docs/plans/2026-05-31_h3-v2-ga-upgrade.md
+++ b/docs/plans/2026-05-31_h3-v2-ga-upgrade.md
@@ -1,12 +1,15 @@
 # h3 v2 GA Upgrade Follow-up
 
 ## Summary
+
 Track removal of the `h3-v2` `npm:h3@2.0.1-rc.20` pin once TanStack Start and the app's SSR/LiveKit pages are validated against h3 v2 GA.
 
 ## Tracking
+
 Tracking ID: H3-V2-GA-2026-05-31
 
 ## Acceptance Criteria
+
 - Upstream h3 v2 GA is available.
 - `@tanstack/start-server-core` or its consumers are confirmed compatible.
 - Frontend typecheck, tests, and end-to-end checks pass after unpinning.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
       "undici": "7.24.0",
       "flatted": "3.4.2",
       "picomatch@^4.0.0": "4.0.4",
+      "fast-uri": "3.1.2",
+      "h3-v2": "npm:h3@2.0.1-rc.20",
       "@tanstack/react-start": "1.167.14",
       "@tanstack/router-plugin": "1.167.10",
       "@tanstack/react-router": "1.168.8"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,26 @@
         ],
         "reference": "https://github.com/nodejs/undici/releases/tag/v7.24.0",
         "note": "Pinned for the current audit cleanup. Undici v7.24.2 is available for reviewer verification or follow-up adoption if acceptable."
+      },
+      "fast-uri": {
+        "mitigates": [
+          "GHSA-q3j6-qgpj-74h6",
+          "GHSA-v39h-62p7-jpjc",
+          "CVE-2026-6322"
+        ],
+        "reference": "https://github.com/fastify/fast-uri/security/advisories/GHSA-v39h-62p7-jpjc",
+        "note": "Pinned to 3.1.2 to keep the URI parsing fixes for the 2026 fast-uri advisories in place. Remove once every transitive consumer accepts >=3.1.2 without an override and upstream no longer needs the pin."
+      },
+      "h3-v2": {
+        "mitigates": [
+          "GHSA-3vj8-jmxq-cgj5",
+          "GHSA-26f5-8h2x-34xh",
+          "GHSA-2j6q-whv2-gh6w",
+          "GHSA-fp4x-ggrf-wmc6",
+          "GHSA-q5pr-72pq-83v3"
+        ],
+        "reference": "https://github.com/TanStack/router/pull/7140",
+        "note": "Pinned to npm:h3@2.0.1-rc.20 because @tanstack/start-server-core still resolves h3 through the v2 alias and this RC is the version validated with the current SSR stack. Remove the alias once h3 v2 GA lands, TanStack Start is confirmed compatible, and the SSR/LiveKit pages have been rechecked. Tracking: H3-V2-GA-2026-05-31 (docs/plans/2026-05-31_h3-v2-ga-upgrade.md)."
       }
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   undici: 7.24.0
   flatted: 3.4.2
   picomatch@^4.0.0: 4.0.4
+  fast-uri: 3.1.2
+  h3-v2: npm:h3@2.0.1-rc.20
   '@tanstack/react-start': 1.167.14
   '@tanstack/router-plugin': 1.167.10
   '@tanstack/react-router': 1.168.8
@@ -1439,8 +1441,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1509,8 +1511,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  h3@2.0.1-rc.16:
-    resolution: {integrity: sha512-h+pjvyujdo9way8qj6FUbhaQcHlR8FEq65EhTX9ViT5pK8aLj68uFl4hBkF+hsTJAH+H1END2Yv6hTIsabGfag==}
+  h3@2.0.1-rc.20:
+    resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==}
     engines: {node: '>=20.11.1'}
     hasBin: true
     peerDependencies:
@@ -3110,7 +3112,7 @@ snapshots:
       '@tanstack/router-core': 1.168.7
       '@tanstack/start-client-core': 1.167.7
       '@tanstack/start-storage-context': 1.166.21
-      h3-v2: h3@2.0.1-rc.16
+      h3-v2: h3@2.0.1-rc.20
       seroval: 1.5.2
     transitivePeerDependencies:
       - crossws
@@ -3337,7 +3339,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3763,7 +3765,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -3817,7 +3819,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  h3@2.0.1-rc.16:
+  h3@2.0.1-rc.20:
     dependencies:
       rou3: 0.8.1
       srvx: 0.11.15


### PR DESCRIPTION
## Summary
- refresh rustls-webpki in backend/Cargo.lock to the patched 0.103.13 release
- override audited frontend transitive dependencies: fast-uri 3.1.2 and h3-v2/h3 2.0.1-rc.20
- keep the AGENTS.md cleanup from this branch

## Testing
- cargo audit --file backend/Cargo.lock
- pnpm audit --audit-level high
- pnpm audit --audit-level moderate
- pnpm --filter frontend typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved Frontend Architecture section formatting and clarified Rust best-practice guidance (avoid unwrap in production)
  * Added an upgrade plan for the upcoming H3 v2 GA with acceptance criteria and tracking details

* **Chores**
  * Adjusted dependency pins/overrides and added review metadata to capture rationale and mitigations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->