### PR TITLE
fix(deploy): skip VPS deploy without secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,11 @@ jobs:
     env:
       OWNER: ${{ github.repository_owner }}
       SHA_TAG: ${{ github.sha }}
+      VPS_HOST: ${{ secrets.VPS_HOST }}
+      VPS_USER: ${{ secrets.VPS_USER }}
+      VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+      VPS_PORT: ${{ secrets.VPS_PORT || '22' }}
+      VPS_APP_DIR: ${{ secrets.VPS_APP_DIR }}
     steps:
       - uses: actions/checkout@v4
 
@@ -48,16 +53,21 @@ jobs:
             ghcr.io/${{ env.OWNER }}/virtual-table-frontend:latest
             ghcr.io/${{ env.OWNER }}/virtual-table-frontend:${{ env.SHA_TAG }}
 
+      - name: Skip VPS deploy when secrets are missing
+        if: ${{ env.VPS_HOST == '' || env.VPS_USER == '' || env.VPS_SSH_KEY == '' || env.VPS_APP_DIR == '' }}
+        run: echo "Skipping VPS deploy because one or more VPS secrets are not configured."
+
       - name: Deploy to VPS
+        if: ${{ env.VPS_HOST != '' && env.VPS_USER != '' && env.VPS_SSH_KEY != '' && env.VPS_APP_DIR != '' }}
         uses: appleboy/ssh-action@v1.2.0
         with:
-          host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_USER }}
-          key: ${{ secrets.VPS_SSH_KEY }}
-          port: ${{ secrets.VPS_PORT || 22 }}
+          host: ${{ env.VPS_HOST }}
+          username: ${{ env.VPS_USER }}
+          key: ${{ env.VPS_SSH_KEY }}
+          port: ${{ env.VPS_PORT }}
           script: |
             set -euo pipefail
-            cd ${{ secrets.VPS_APP_DIR }}
+            cd ${{ env.VPS_APP_DIR }}
             export GITHUB_REPOSITORY_OWNER=${{ env.OWNER }}
             export IMAGE_TAG=${{ env.SHA_TAG }}
             docker compose -f infrastructure/docker-compose.vps.yml pull


### PR DESCRIPTION
## Summary
- expose VPS secrets through job env for deploy gating
- skip the SSH deploy step when required VPS secrets are not configured, while still building/pushing images

## Validation
- CI will validate on this PR
- Previous deploy run confirmed image builds now complete; failure was missing VPS secrets