### PR TITLE
fix(frontend): show chosen participant names

### DIFF
--- a/frontend/e2e/whisper.spec.ts
+++ b/frontend/e2e/whisper.spec.ts
@@ -39,7 +39,7 @@ async function openParticipant(browser: Browser, room: string, displayName: stri
   return { context, page, identity };
 }
 
-async function expectRosterName(page: Page, displayName: string, identity: string): Promise<void> {
+async function expectRosterName(page: Page, identity: string, displayName: string): Promise<void> {
   const roster = page.getByTestId("participant-roster");
   await expect(roster).toContainText(displayName);
   await expect(roster).not.toContainText(identity);
@@ -102,8 +102,8 @@ test.describe("whisper multi-client flows", () => {
 
     try {
       await Promise.all([
-        expectRosterName(alice.page, "Alice", alice.identity),
-        expectRosterName(bob.page, "Bob", bob.identity)
+        expectRosterName(alice.page, alice.identity, "Alice"),
+        expectRosterName(bob.page, bob.identity, "Bob")
       ]);
       await Promise.all([ensureCameraOn(alice.page), ensureCameraOn(bob.page)]);
       await Promise.all([
@@ -114,8 +114,8 @@ test.describe("whisper multi-client flows", () => {
       ]);
 
       await Promise.all([
-        expectRosterName(alice.page, "Bob", bob.identity),
-        expectRosterName(bob.page, "Alice", alice.identity),
+        expectRosterName(alice.page, bob.identity, "Bob"),
+        expectRosterName(bob.page, alice.identity, "Alice"),
         expectVideoTileName(alice.page, alice.identity, "Alice"),
         expectVideoTileName(alice.page, bob.identity, "Bob"),
         expectVideoTileName(bob.page, alice.identity, "Alice"),

--- a/frontend/e2e/whisper.spec.ts
+++ b/frontend/e2e/whisper.spec.ts
@@ -39,6 +39,18 @@ async function openParticipant(browser: Browser, room: string, displayName: stri
   return { context, page, identity };
 }
 
+async function expectRosterName(page: Page, displayName: string, identity: string): Promise<void> {
+  const roster = page.getByTestId("participant-roster");
+  await expect(roster).toContainText(displayName);
+  await expect(roster).not.toContainText(identity);
+}
+
+async function expectVideoTileName(page: Page, identity: string, displayName: string): Promise<void> {
+  const tileLabel = localTile(page, identity).getByTestId("video-tile-label");
+  await expect(tileLabel).toContainText(displayName);
+  await expect(tileLabel).not.toContainText(identity);
+}
+
 async function ensureCameraOn(page: Page): Promise<void> {
   const cameraButton = page.getByRole("button", { name: /Camera (On|Off)/ });
   await expect(cameraButton).toBeVisible();
@@ -84,6 +96,37 @@ async function whisperCardForMember(page: Page, memberIdentity: string) {
 }
 
 test.describe("whisper multi-client flows", () => {
+  test("renders chosen display names in roster and video tiles", async ({ browser }) => {
+    const alice = await openParticipant(browser, TEST_ROOM, "Alice");
+    const bob = await openParticipant(browser, TEST_ROOM, "Bob");
+
+    try {
+      await Promise.all([
+        expectRosterName(alice.page, "Alice", alice.identity),
+        expectRosterName(bob.page, "Bob", bob.identity)
+      ]);
+      await Promise.all([ensureCameraOn(alice.page), ensureCameraOn(bob.page)]);
+      await Promise.all([
+        waitForVideoPlayback(alice.page, alice.identity),
+        waitForVideoPlayback(alice.page, bob.identity),
+        waitForVideoPlayback(bob.page, alice.identity),
+        waitForVideoPlayback(bob.page, bob.identity)
+      ]);
+
+      await Promise.all([
+        expectRosterName(alice.page, "Bob", bob.identity),
+        expectRosterName(bob.page, "Alice", alice.identity),
+        expectVideoTileName(alice.page, alice.identity, "Alice"),
+        expectVideoTileName(alice.page, bob.identity, "Bob"),
+        expectVideoTileName(bob.page, alice.identity, "Alice"),
+        expectVideoTileName(bob.page, bob.identity, "Bob")
+      ]);
+    } finally {
+      await alice.context.close();
+      await bob.context.close();
+    }
+  });
+
   test("toggles mirrored self-view from the device panel and persists it on reload", async ({ browser }) => {
     const alice = await openParticipant(browser, TEST_ROOM, "Alice");
 

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -5,7 +5,16 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   {
-    ignores: ["dist", "node_modules", ".next", ".tanstack", ".vinxi", "src/routeTree.gen.ts"]
+    ignores: [
+      "dist",
+      "node_modules",
+      ".next",
+      ".tanstack",
+      ".vinxi",
+      "playwright-report",
+      "test-results",
+      "src/routeTree.gen.ts"
+    ]
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/frontend/src/features/room-session/components/ParticipantRoster.tsx
+++ b/frontend/src/features/room-session/components/ParticipantRoster.tsx
@@ -7,7 +7,7 @@ type ParticipantRosterProps = {
 
 export function ParticipantRoster({ participantRoster, title = "AT TABLE" }: ParticipantRosterProps) {
   return (
-    <div className="px-5 pt-4 pb-4">
+    <div className="px-5 pt-4 pb-4" data-testid="participant-roster">
       <h3 className="display-face text-xs tracking-[0.08em] text-[var(--c-text-warm)]">{title}</h3>
       <div className="mt-3">
         {participantRoster.map((participant, index) => (

--- a/frontend/src/features/room-session/components/RoomSessionController.tsx
+++ b/frontend/src/features/room-session/components/RoomSessionController.tsx
@@ -5,6 +5,7 @@ import { DevicePanel } from "@/features/room-session/components/DevicePanel";
 import { ParticipantRoster } from "@/features/room-session/components/ParticipantRoster";
 import { RemoteAudioLayer } from "@/features/room-session/components/RemoteAudioLayer";
 import { RoomSessionLayout } from "@/features/room-session/components/RoomSessionLayout";
+import { RoomSessionState } from "@/features/room-session/components/RoomSessionState";
 import { RoomTopBar } from "@/features/room-session/components/RoomTopBar";
 import { SessionSidebar } from "@/features/room-session/components/SessionSidebar";
 import { SplitControlPanel } from "@/features/room-session/components/SplitControlPanel";
@@ -13,9 +14,9 @@ import { VideoGrid } from "@/features/room-session/components/VideoGrid";
 import { WhisperPanel } from "@/features/room-session/components/WhisperPanel";
 import { useRoomConnection } from "@/features/room-session/hooks/useRoomConnection";
 import { useRoomMedia } from "@/features/room-session/hooks/useRoomMedia";
+import { useRoomParticipants } from "@/features/room-session/hooks/useRoomParticipants";
 import { useSplitRoomSession } from "@/features/room-session/hooks/useSplitRoomSession";
 import { useWhisperSession } from "@/features/room-session/hooks/useWhisperSession";
-import { formatIdentityLabel } from "@/features/room-session/lib/session-helpers";
 import {
   buildAudioTracks,
   buildParticipantRoster,
@@ -24,6 +25,7 @@ import {
   filterParticipantIdentitiesForSplitView,
   filterVideoTilesForSplitView,
   orderGridTiles,
+  resolveParticipantLabel,
   resolveParticipantRoomId
 } from "@/features/room-session/lib/session-selectors";
 
@@ -37,18 +39,12 @@ export function RoomSessionController({ roomName, displayName }: RoomSessionCont
 
   const connection = useRoomConnection({ roomName, displayName });
   const media = useRoomMedia({ room: connection.room });
-  const participantIdentities = useMemo(() => {
-    const version = connection.renderVersion;
-    void version;
-
-    if (!connection.identity) {
-      return connection.room ? Array.from(connection.room.remoteParticipants.keys()) : [];
-    }
-
-    return Array.from(
-      new Set([connection.identity, ...Array.from(connection.room?.remoteParticipants.keys() ?? [])])
-    );
-  }, [connection.identity, connection.renderVersion, connection.room]);
+  const { participantDisplayNames, participantIdentities } = useRoomParticipants({
+    room: connection.room,
+    identity: connection.identity,
+    renderVersion: connection.renderVersion,
+    displayName
+  });
   const splitSession = useSplitRoomSession({
     room: connection.room,
     identity: connection.identity,
@@ -134,6 +130,7 @@ export function RoomSessionController({ roomName, displayName }: RoomSessionCont
     () =>
       buildParticipantRoster({
         participantIdentities: visibleParticipantIdentities,
+        participantDisplayNames,
         identity: connection.identity,
         activeSpeakers: connection.activeSpeakers,
         videoTiles: visibleVideoTiles,
@@ -143,6 +140,7 @@ export function RoomSessionController({ roomName, displayName }: RoomSessionCont
     [
       connection.activeSpeakers,
       connection.identity,
+      participantDisplayNames,
       visibleParticipantIdentities,
       visibleVideoTiles,
       whisperSession.activeWhispers,
@@ -159,7 +157,7 @@ export function RoomSessionController({ roomName, displayName }: RoomSessionCont
       participantIdentities
         .map((participantIdentity) => ({
           identity: participantIdentity,
-          label: formatIdentityLabel(participantIdentity),
+          label: resolveParticipantLabel(participantIdentity, participantDisplayNames),
           isLocal: participantIdentity === connection.identity,
           roomId: resolveParticipantRoomId(splitSession.splitState, participantIdentity)
         }))
@@ -181,7 +179,7 @@ export function RoomSessionController({ roomName, displayName }: RoomSessionCont
           }
           return left.label.localeCompare(right.label);
         }),
-    [connection.identity, participantIdentities, splitSession.splitState]
+    [connection.identity, participantDisplayNames, participantIdentities, splitSession.splitState]
   );
   const splitPanel =
     splitSession.canManageSplitRooms || splitSession.isActive || splitSession.notice ? (
@@ -212,33 +210,15 @@ export function RoomSessionController({ roomName, displayName }: RoomSessionCont
     ) : undefined;
 
   if (isConnecting) {
-    return (
-      <div className="flex h-screen items-center justify-center bg-[var(--c-void)]">
-        <div className="text-center">
-          <p className="display-face text-xl text-[var(--c-text-warm)]">Entering the table</p>
-          <p className="mt-3 text-sm text-[var(--c-text-dim)]">Connecting to room...</p>
-        </div>
-      </div>
-    );
+    return <RoomSessionState title="Entering the table" message="Connecting to room..." />;
   }
 
   if (error) {
-    return (
-      <div className="flex h-screen items-center justify-center bg-[var(--c-void)]">
-        <div className="max-w-md text-center">
-          <p className="display-face text-xl text-[var(--c-ember)]">Connection Failed</p>
-          <p className="mt-3 text-sm text-[var(--c-text-dim)]">{error}</p>
-        </div>
-      </div>
-    );
+    return <RoomSessionState title="Connection Failed" message={error} tone="error" />;
   }
 
   if (!connection.room) {
-    return (
-      <div className="flex h-screen items-center justify-center bg-[var(--c-void)]">
-        <p className="text-sm text-[var(--c-text-dim)]">Room is not connected.</p>
-      </div>
-    );
+    return <RoomSessionState message="Room is not connected." />;
   }
 
   return (
@@ -270,6 +250,7 @@ export function RoomSessionController({ roomName, displayName }: RoomSessionCont
           gridCount={Math.min(gridTiles.length, 12)}
           spotlightIdentity={whisperSession.spotlightIdentity}
           activeSpeakers={connection.activeSpeakers}
+          participantDisplayNames={participantDisplayNames}
           selectedParticipantIds={whisperSession.selectedParticipantIds}
           mirrorSelfView={media.mirrorSelfView}
           onToggleParticipantSelection={whisperSession.toggleParticipantSelection}

--- a/frontend/src/features/room-session/components/RoomSessionState.tsx
+++ b/frontend/src/features/room-session/components/RoomSessionState.tsx
@@ -1,0 +1,18 @@
+type RoomSessionStateProps = {
+  title?: string;
+  message: string;
+  tone?: "default" | "error";
+};
+
+export function RoomSessionState({ title, message, tone = "default" }: RoomSessionStateProps) {
+  const titleClass = tone === "error" ? "text-[var(--c-ember)]" : "text-[var(--c-text-warm)]";
+
+  return (
+    <div className="flex h-screen items-center justify-center bg-[var(--c-void)]">
+      <div className={title ? "max-w-md text-center" : "text-center"}>
+        {title ? <p className={`display-face text-xl ${titleClass}`}>{title}</p> : null}
+        <p className={title ? "mt-3 text-sm text-[var(--c-text-dim)]" : "text-sm text-[var(--c-text-dim)]"}>{message}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/room-session/components/RoomSessionState.tsx
+++ b/frontend/src/features/room-session/components/RoomSessionState.tsx
@@ -6,12 +6,20 @@ type RoomSessionStateProps = {
 
 export function RoomSessionState({ title, message, tone = "default" }: RoomSessionStateProps) {
   const titleClass = tone === "error" ? "text-[var(--c-ember)]" : "text-[var(--c-text-warm)]";
+  const isError = tone === "error";
 
   return (
     <div className="flex h-screen items-center justify-center bg-[var(--c-void)]">
       <div className={title ? "max-w-md text-center" : "text-center"}>
         {title ? <p className={`display-face text-xl ${titleClass}`}>{title}</p> : null}
-        <p className={title ? "mt-3 text-sm text-[var(--c-text-dim)]" : "text-sm text-[var(--c-text-dim)]"}>{message}</p>
+        <p
+          aria-atomic={isError ? "true" : undefined}
+          aria-live={isError ? "assertive" : undefined}
+          className={title ? "mt-3 text-sm text-[var(--c-text-dim)]" : "text-sm text-[var(--c-text-dim)]"}
+          role={isError ? "alert" : undefined}
+        >
+          {message}
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/features/room-session/components/SplitControlPanel.tsx
+++ b/frontend/src/features/room-session/components/SplitControlPanel.tsx
@@ -1,13 +1,9 @@
 import { useState } from "react";
+import { SplitParticipantAssignmentRow } from "@/features/room-session/components/SplitParticipantAssignmentRow";
+import type { SplitParticipantOption } from "@/features/room-session/components/SplitParticipantAssignmentRow";
 import { resolveParticipantRoomId } from "@/features/room-session/lib/session-selectors";
 import { canAddSideRoom } from "@/features/room-session/lib/split-room-rules";
-import type { SplitRoom, SplitState } from "@/lib/protocol";
-
-type SplitParticipantOption = {
-  identity: string;
-  label: string;
-  isLocal: boolean;
-};
+import type { SplitState } from "@/lib/protocol";
 
 type SplitControlPanelProps = {
   splitState: SplitState;
@@ -200,7 +196,7 @@ export function SplitControlPanel({
 
             <div className="mt-4 space-y-3">
               {participants.map((participant) => (
-                <ParticipantAssignmentRow
+                <SplitParticipantAssignmentRow
                   key={participant.identity}
                   participant={participant}
                   rooms={splitState.rooms}
@@ -218,72 +214,3 @@ export function SplitControlPanel({
   );
 }
 
-type ParticipantAssignmentRowProps = {
-  participant: SplitParticipantOption;
-  rooms: SplitRoom[];
-  splitState: SplitState;
-  disabled: boolean;
-  isPinnedToGmRole: boolean;
-  onAssignParticipantToRoom: (participantIdentity: string, roomId: string) => Promise<boolean>;
-};
-
-function ParticipantAssignmentRow({
-  participant,
-  rooms,
-  splitState,
-  disabled,
-  isPinnedToGmRole,
-  onAssignParticipantToRoom
-}: ParticipantAssignmentRowProps) {
-  const assignedRoomId = resolveParticipantRoomId(splitState, participant.identity);
-  const assignedRoomName = rooms.find((room) => room.id === assignedRoomId)?.name ?? "Main Table";
-
-  return (
-    <div className="rounded-md border border-[var(--c-rule)] bg-[color-mix(in_srgb,var(--c-ink)_68%,black)] px-3 py-3">
-      <div className="flex items-center justify-between gap-3 text-[11px]">
-        <span className="truncate text-[var(--c-text)]">
-          {participant.label}
-          {participant.isLocal ? <span className="ml-1 text-[var(--c-text-faint)]">(you)</span> : null}
-          {participant.identity === splitState.gmIdentity ? <span className="ml-1 text-[var(--c-gold)]">GM</span> : null}
-        </span>
-        {participant.identity !== splitState.gmIdentity ? (
-          <span className="shrink-0 text-[var(--c-text-faint)]">{assignedRoomName}</span>
-        ) : null}
-      </div>
-
-      {isPinnedToGmRole ? (
-        <p className="mt-3 text-[10px] uppercase tracking-[0.06em] text-[var(--c-text-faint)]">
-          GM is globally visible across all rooms
-        </p>
-      ) : (
-        <>
-          <p className="mt-3 text-[10px] uppercase tracking-[0.06em] text-[var(--c-text-faint)]">
-            Choose a room
-          </p>
-          <div className="mt-2 flex flex-wrap gap-2">
-            {rooms.map((room) => {
-              const isAssigned = room.id === assignedRoomId;
-
-              return (
-                <button
-                  key={room.id}
-                  aria-pressed={isAssigned}
-                  className={
-                    isAssigned
-                      ? "rounded-sm border border-[var(--c-gold-dim)] bg-[color-mix(in_srgb,var(--c-gold)_16%,transparent)] px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.06em] text-[var(--c-gold)] transition-colors"
-                      : "rounded-sm border border-[var(--c-rule)] px-2.5 py-1.5 text-[10px] font-medium uppercase tracking-[0.06em] text-[var(--c-text-dim)] transition-colors hover:border-[var(--c-text-faint)] hover:text-[var(--c-text)]"
-                  }
-                  disabled={disabled}
-                  onClick={() => void onAssignParticipantToRoom(participant.identity, room.id)}
-                  type="button"
-                >
-                  {room.name}
-                </button>
-              );
-            })}
-          </div>
-        </>
-      )}
-    </div>
-  );
-}

--- a/frontend/src/features/room-session/components/SplitParticipantAssignmentRow.tsx
+++ b/frontend/src/features/room-session/components/SplitParticipantAssignmentRow.tsx
@@ -1,0 +1,78 @@
+import { resolveParticipantRoomId } from "@/features/room-session/lib/session-selectors";
+import type { SplitRoom, SplitState } from "@/lib/protocol";
+
+export type SplitParticipantOption = {
+  identity: string;
+  label: string;
+  isLocal: boolean;
+};
+
+type SplitParticipantAssignmentRowProps = {
+  participant: SplitParticipantOption;
+  rooms: SplitRoom[];
+  splitState: SplitState;
+  disabled: boolean;
+  isPinnedToGmRole: boolean;
+  onAssignParticipantToRoom: (participantIdentity: string, roomId: string) => Promise<boolean>;
+};
+
+export function SplitParticipantAssignmentRow({
+  participant,
+  rooms,
+  splitState,
+  disabled,
+  isPinnedToGmRole,
+  onAssignParticipantToRoom
+}: SplitParticipantAssignmentRowProps) {
+  const assignedRoomId = resolveParticipantRoomId(splitState, participant.identity);
+  const assignedRoomName = rooms.find((room) => room.id === assignedRoomId)?.name ?? "Main Table";
+
+  return (
+    <div className="rounded-md border border-[var(--c-rule)] bg-[color-mix(in_srgb,var(--c-ink)_68%,black)] px-3 py-3">
+      <div className="flex items-center justify-between gap-3 text-[11px]">
+        <span className="truncate text-[var(--c-text)]">
+          {participant.label}
+          {participant.isLocal ? <span className="ml-1 text-[var(--c-text-faint)]">(you)</span> : null}
+          {participant.identity === splitState.gmIdentity ? <span className="ml-1 text-[var(--c-gold)]">GM</span> : null}
+        </span>
+        {participant.identity !== splitState.gmIdentity ? (
+          <span className="shrink-0 text-[var(--c-text-faint)]">{assignedRoomName}</span>
+        ) : null}
+      </div>
+
+      {isPinnedToGmRole ? (
+        <p className="mt-3 text-[10px] uppercase tracking-[0.06em] text-[var(--c-text-faint)]">
+          GM is globally visible across all rooms
+        </p>
+      ) : (
+        <>
+          <p className="mt-3 text-[10px] uppercase tracking-[0.06em] text-[var(--c-text-faint)]">
+            Choose a room
+          </p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {rooms.map((room) => {
+              const isAssigned = room.id === assignedRoomId;
+
+              return (
+                <button
+                  key={room.id}
+                  aria-pressed={isAssigned}
+                  className={
+                    isAssigned
+                      ? "rounded-sm border border-[var(--c-gold-dim)] bg-[color-mix(in_srgb,var(--c-gold)_16%,transparent)] px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.06em] text-[var(--c-gold)] transition-colors"
+                      : "rounded-sm border border-[var(--c-rule)] px-2.5 py-1.5 text-[10px] font-medium uppercase tracking-[0.06em] text-[var(--c-text-dim)] transition-colors hover:border-[var(--c-text-faint)] hover:text-[var(--c-text)]"
+                  }
+                  disabled={disabled}
+                  onClick={() => void onAssignParticipantToRoom(participant.identity, room.id)}
+                  type="button"
+                >
+                  {room.name}
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/room-session/components/SplitParticipantAssignmentRow.tsx
+++ b/frontend/src/features/room-session/components/SplitParticipantAssignmentRow.tsx
@@ -26,6 +26,7 @@ export function SplitParticipantAssignmentRow({
 }: SplitParticipantAssignmentRowProps) {
   const assignedRoomId = resolveParticipantRoomId(splitState, participant.identity);
   const assignedRoomName = rooms.find((room) => room.id === assignedRoomId)?.name ?? "Main Table";
+  const isGm = isPinnedToGmRole || participant.identity === splitState.gmIdentity;
 
   return (
     <div className="rounded-md border border-[var(--c-rule)] bg-[color-mix(in_srgb,var(--c-ink)_68%,black)] px-3 py-3">
@@ -33,14 +34,14 @@ export function SplitParticipantAssignmentRow({
         <span className="truncate text-[var(--c-text)]">
           {participant.label}
           {participant.isLocal ? <span className="ml-1 text-[var(--c-text-faint)]">(you)</span> : null}
-          {participant.identity === splitState.gmIdentity ? <span className="ml-1 text-[var(--c-gold)]">GM</span> : null}
+          {isGm ? <span className="ml-1 text-[var(--c-gold)]">GM</span> : null}
         </span>
-        {participant.identity !== splitState.gmIdentity ? (
+        {!isGm ? (
           <span className="shrink-0 text-[var(--c-text-faint)]">{assignedRoomName}</span>
         ) : null}
       </div>
 
-      {isPinnedToGmRole ? (
+      {isGm ? (
         <p className="mt-3 text-[10px] uppercase tracking-[0.06em] text-[var(--c-text-faint)]">
           GM is globally visible across all rooms
         </p>

--- a/frontend/src/features/room-session/components/VideoGrid.tsx
+++ b/frontend/src/features/room-session/components/VideoGrid.tsx
@@ -1,11 +1,13 @@
 import type { VideoTileModel } from "@/features/room-session/types";
 import { VideoTile } from "@/features/room-session/components/VideoTile";
+import { resolveParticipantLabel } from "@/features/room-session/lib/session-selectors";
 
 type VideoGridProps = {
   gridTiles: VideoTileModel[];
   gridCount: number;
   spotlightIdentity?: string;
   activeSpeakers: Set<string>;
+  participantDisplayNames: ReadonlyMap<string, string>;
   selectedParticipantIds: Set<string>;
   mirrorSelfView: boolean;
   onToggleParticipantSelection: (participantIdentity: string) => void;
@@ -17,6 +19,7 @@ export function VideoGrid({
   gridCount,
   spotlightIdentity,
   activeSpeakers,
+  participantDisplayNames,
   selectedParticipantIds,
   mirrorSelfView,
   onToggleParticipantSelection,
@@ -35,6 +38,7 @@ export function VideoGrid({
               isActiveSpeaker={activeSpeakers.has(tile.identity)}
               isSelectedForInvite={!tile.isLocal && selectedParticipantIds.has(tile.identity)}
               mirrorSelfView={mirrorSelfView}
+              participantLabel={resolveParticipantLabel(tile.identity, participantDisplayNames)}
               onToggleParticipantSelection={onToggleParticipantSelection}
               onToggleSpotlight={onToggleSpotlight}
             />

--- a/frontend/src/features/room-session/components/VideoTile.tsx
+++ b/frontend/src/features/room-session/components/VideoTile.tsx
@@ -1,10 +1,10 @@
 import { TrackElement } from "@/components/TrackElement";
-import { formatIdentityLabel } from "@/features/room-session/lib/session-helpers";
 import type { VideoTileModel } from "@/features/room-session/types";
 
 type VideoTileProps = {
   tile: VideoTileModel;
   index: number;
+  participantLabel: string;
   isSpotlighted: boolean;
   isActiveSpeaker: boolean;
   isSelectedForInvite: boolean;
@@ -16,6 +16,7 @@ type VideoTileProps = {
 export function VideoTile({
   tile,
   index,
+  participantLabel,
   isSpotlighted,
   isActiveSpeaker,
   isSelectedForInvite,
@@ -52,8 +53,8 @@ export function VideoTile({
       <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/80 to-transparent opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
       <div className="absolute inset-x-0 bottom-0 flex items-end justify-between gap-3 p-3 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
         <div className="min-w-0">
-          <p className="display-face truncate text-sm leading-tight text-white/90">
-            {formatIdentityLabel(tile.identity)}
+          <p className="display-face truncate text-sm leading-tight text-white/90" data-testid="video-tile-label">
+            {participantLabel}
             {tile.isLocal ? " (you)" : ""}
           </p>
           {isActiveSpeaker && <p className="mt-0.5 text-[10px] text-[var(--c-emerald)]">Speaking</p>}

--- a/frontend/src/features/room-session/hooks/useRoomConnection.ts
+++ b/frontend/src/features/room-session/hooks/useRoomConnection.ts
@@ -160,6 +160,7 @@ export function useRoomConnection({ roomName, displayName }: UseRoomConnectionIn
       RoomEvent.ParticipantConnected,
       RoomEvent.ParticipantDisconnected,
       RoomEvent.TrackPublished,
+      RoomEvent.ParticipantNameChanged,
       RoomEvent.TrackUnpublished,
       RoomEvent.TrackSubscribed,
       RoomEvent.TrackUnsubscribed,

--- a/frontend/src/features/room-session/hooks/useRoomParticipants.ts
+++ b/frontend/src/features/room-session/hooks/useRoomParticipants.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useMemo } from "react";
+import type { Room } from "livekit-client";
+import { buildParticipantDisplayNames } from "@/features/room-session/lib/session-selectors";
+
+type UseRoomParticipantsInput = {
+  room: Room | null;
+  identity: string;
+  renderVersion: number;
+  displayName: string;
+};
+
+export function useRoomParticipants({ room, identity, renderVersion, displayName }: UseRoomParticipantsInput) {
+  const participantIdentities = useMemo(() => {
+    void renderVersion;
+
+    if (!identity) {
+      return room ? Array.from(room.remoteParticipants.keys()) : [];
+    }
+
+    return Array.from(new Set([identity, ...Array.from(room?.remoteParticipants.keys() ?? [])]));
+  }, [identity, renderVersion, room]);
+
+  const participantDisplayNames = useMemo(() => {
+    void renderVersion;
+
+    return buildParticipantDisplayNames(room, identity, displayName);
+  }, [displayName, identity, renderVersion, room]);
+
+  return { participantDisplayNames, participantIdentities };
+}

--- a/frontend/src/features/room-session/lib/session-selectors.test.ts
+++ b/frontend/src/features/room-session/lib/session-selectors.test.ts
@@ -6,6 +6,7 @@ import {
   filterAudioTracksForSplitView,
   filterParticipantIdentitiesForSplitView,
   orderGridTiles,
+  resolveParticipantLabel,
   resolveParticipantRoomId
 } from "@/features/room-session/lib/session-selectors";
 import type { AudioTrackModel, VideoTileModel } from "@/features/room-session/types";
@@ -36,6 +37,26 @@ describe("room session selectors", () => {
         updatedAt: 1
       })
     ).toBe("Whisper abcdef");
+  });
+
+  it("uses chosen display names for participant roster labels", () => {
+    const roster = buildParticipantRoster({
+      participantIdentities: ["u_alice", "u_bob"],
+      participantDisplayNames: new Map([
+        ["u_alice", "Alice the Brave"],
+        ["u_bob", "Bobby Tables"]
+      ]),
+      identity: "u_alice",
+      activeSpeakers: new Set(),
+      videoTiles: [],
+      activeWhispers: []
+    });
+
+    expect(roster.map((participant) => participant.label)).toEqual(["Alice the Brave", "Bobby Tables"]);
+  });
+
+  it("falls back to formatted identities when display names are unavailable", () => {
+    expect(resolveParticipantLabel("alice-the-brave-abc123def456", new Map())).toBe("Alice The Brave");
   });
 
   it("sorts the participant roster by spotlight then local identity", () => {

--- a/frontend/src/features/room-session/lib/session-selectors.ts
+++ b/frontend/src/features/room-session/lib/session-selectors.ts
@@ -86,8 +86,50 @@ export function buildAudioTracks(room: Room | null): AudioTrackModel[] {
   return tracks;
 }
 
+export function buildParticipantDisplayNames(
+  room: Room | null,
+  localIdentity: string,
+  localDisplayName: string
+): Map<string, string> {
+  const displayNames = new Map<string, string>();
+  addDisplayName(displayNames, localIdentity, localDisplayName);
+
+  if (!room) {
+    return displayNames;
+  }
+
+  addDisplayName(
+    displayNames,
+    room.localParticipant.identity || localIdentity,
+    room.localParticipant.name || localDisplayName
+  );
+  room.remoteParticipants.forEach((participant) => {
+    addDisplayName(displayNames, participant.identity, participant.name);
+  });
+
+  return displayNames;
+}
+
+export function resolveParticipantLabel(
+  identity: string,
+  participantDisplayNames?: ReadonlyMap<string, string>
+): string {
+  const displayName = participantDisplayNames?.get(identity);
+  return displayName && displayName.length > 0 ? displayName : formatIdentityLabel(identity);
+}
+
+function addDisplayName(displayNames: Map<string, string>, identity: string | undefined, displayName: string | undefined) {
+  const trimmedDisplayName = displayName?.trim();
+  if (!identity || !trimmedDisplayName) {
+    return;
+  }
+
+  displayNames.set(identity, trimmedDisplayName);
+}
+
 type BuildParticipantRosterInput = {
   participantIdentities: string[];
+  participantDisplayNames?: ReadonlyMap<string, string>;
   identity: string;
   activeSpeakers: Set<string>;
   videoTiles: VideoTileModel[];
@@ -97,6 +139,7 @@ type BuildParticipantRosterInput = {
 
 export function buildParticipantRoster({
   participantIdentities,
+  participantDisplayNames,
   identity,
   activeSpeakers,
   videoTiles,
@@ -108,7 +151,7 @@ export function buildParticipantRoster({
       const whisper = activeWhispers.find((entry) => entry.members.includes(participantIdentity));
       return {
         identity: participantIdentity,
-        label: formatIdentityLabel(participantIdentity),
+        label: resolveParticipantLabel(participantIdentity, participantDisplayNames),
         isLocal: participantIdentity === identity,
         isSpotlight: participantIdentity === spotlightIdentity,
         isSpeaking: activeSpeakers.has(participantIdentity),


### PR DESCRIPTION
## Summary
- show chosen participant display names in the table roster and video tile labels
- keep participant display-name derivation in a dedicated room participants hook
- extract small room-session UI components to keep the controller focused

## Verification
- `pnpm --filter frontend test -- src/features/room-session/lib/session-selectors.test.ts`
- `pnpm --filter frontend typecheck`
- `pnpm --filter frontend lint`
- targeted Playwright multi-client test: `renders chosen display names in roster and video tiles`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Participants' chosen display names now appear in the roster and on video tiles.
  * Room state screens now render clearer, accessible messages for connection/error states.

* **Tests**
  * Added end-to-end test validating display names render correctly across participants.
  * Added unit tests for roster label resolution with and without display-name mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->