### PR TITLE
chore(frontend): simplify landing page copy

### DIFF
--- a/frontend/e2e/auth-admin.spec.ts
+++ b/frontend/e2e/auth-admin.spec.ts
@@ -14,9 +14,9 @@ function devLoginUrl(email: string, next: string, name: string): string {
 test("home page requires sign-in before join form is shown", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "Enter through Google" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Use your game account" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Continue with Google" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Join the table" })).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: "Join the room" })).toHaveCount(0);
 });
 
 test("admin can manage users and non-admin is blocked from the admin console", async ({ browser }) => {

--- a/frontend/src/components/JoinForm.tsx
+++ b/frontend/src/components/JoinForm.tsx
@@ -27,10 +27,10 @@ export function JoinForm({ initialName = "" }: JoinFormProps) {
 
   return (
     <section className="w-full max-w-sm">
-      <p className="text-[10px] uppercase tracking-[0.12em] text-[var(--c-text-faint)]">Enter the room</p>
-      <h1 className="display-face mt-2 text-2xl text-[var(--c-text-warm)]">Join the table</h1>
+      <p className="text-[10px] uppercase tracking-[0.12em] text-[var(--c-text-faint)]">Almost there</p>
+      <h1 className="display-face mt-2 text-2xl text-[var(--c-text-warm)]">Join the room</h1>
       <p className="mt-3 text-sm leading-relaxed text-[var(--c-text-dim)]">
-        Choose the nickname your group knows you by and step into the room. Whispers and spotlight stay inside.
+        Pick the name we'll recognize. Leave the room as-is unless someone gave you a different one.
       </p>
       <form className="mt-8 space-y-6" onSubmit={onSubmit}>
         <label className="block text-[10px] uppercase tracking-[0.06em] text-[var(--c-text-dim)]">

--- a/frontend/src/features/auth/components/AuthLanding.tsx
+++ b/frontend/src/features/auth/components/AuthLanding.tsx
@@ -22,46 +22,44 @@ export function AuthLanding({ user, onLogout, isLoggingOut }: AuthLandingProps) 
     <main className="flex min-h-screen items-center bg-[var(--c-void)]">
       <div className="mx-auto grid w-full max-w-6xl gap-16 px-8 py-12 lg:grid-cols-[1fr_360px] lg:items-center lg:gap-24">
         <section>
-          <p className="text-[10px] uppercase tracking-[0.14em] text-[var(--c-text-faint)]">
-            Google-authenticated room access with backend-owned session control
-          </p>
+          <p className="text-[10px] uppercase tracking-[0.14em] text-[var(--c-text-faint)]">Private game night</p>
           <h1 className="display-face mt-4 max-w-2xl text-5xl leading-[1.02] text-[var(--c-text-warm)] md:text-6xl">
-            Virtual Table
+            Welcome to the table
           </h1>
           <p className="mt-6 max-w-xl text-base leading-7 text-[var(--c-text-dim)]">
-            Spotlight, whispers, and one steady room identity per player. The table opens only for explicitly allowed
-            accounts, and the backend owns who gets to walk in.
+            If you're here, you already know what this is. Sign in with the Google account we added, pick the name
+            everyone knows you by, and join the room.
           </p>
 
           <div className="mt-12 grid gap-8 md:grid-cols-3">
             <div>
-              <h2 className="display-face text-base text-[var(--c-text-warm)]">Allowlist</h2>
+              <h2 className="display-face text-base text-[var(--c-text-warm)]">Same room</h2>
               <p className="mt-2 text-sm leading-6 text-[var(--c-text-dim)]">
-                Access is tied to the Google account the group agreed on. No join key drift, no copied secrets.
+                Use the usual room unless someone said otherwise.
               </p>
             </div>
             <div>
-              <h2 className="display-face text-base text-[var(--c-text-warm)]">Stable identity</h2>
+              <h2 className="display-face text-base text-[var(--c-text-warm)]">Whispers</h2>
               <p className="mt-2 text-sm leading-6 text-[var(--c-text-dim)]">
-                LiveKit identity is derived server-side from Google, while the nickname you display stays editable.
+                Step aside for a quick private chat without leaving the table.
               </p>
             </div>
             <div>
-              <h2 className="display-face text-base text-[var(--c-text-warm)]">Admin control</h2>
+              <h2 className="display-face text-base text-[var(--c-text-warm)]">GM spotlight</h2>
               <p className="mt-2 text-sm leading-6 text-[var(--c-text-dim)]">
-                Admins manage players, gamemasters, and active access from one backend-owned user list.
+                When the GM needs everyone's eyes in one place, follow the spotlight.
               </p>
             </div>
           </div>
 
           <div className="mt-10 flex flex-wrap gap-x-6 gap-y-2 border-t border-[var(--c-rule)] pt-5 text-[11px] text-[var(--c-text-faint)]">
             <span>
-              Hold <kbd className="font-mono text-[var(--c-text-dim)]">V</kbd> for whisper push-to-talk
+              Hold <kbd className="font-mono text-[var(--c-text-dim)]">V</kbd> to whisper
             </span>
             <span>
               Press <kbd className="font-mono text-[var(--c-text-dim)]">G</kbd> to leave a whisper
             </span>
-            {user ? <span>Signed in as {user.email}</span> : <span>Google sign-in required before joining</span>}
+            {user ? <span>Signed in as {user.email}</span> : <span>Sign in first, then join</span>}
           </div>
         </section>
 
@@ -70,7 +68,7 @@ export function AuthLanding({ user, onLogout, isLoggingOut }: AuthLandingProps) 
             <div className="flex items-start justify-between gap-4">
               <div>
                 <p className="text-[10px] uppercase tracking-[0.12em] text-[var(--c-text-faint)]">Authenticated</p>
-                <h2 className="display-face mt-2 text-2xl text-[var(--c-text-warm)]">{fallbackName(user)}</h2>
+                <h2 className="display-face mt-2 text-2xl text-[var(--c-text-warm)]">You're signed in</h2>
                 <p className="mt-2 text-sm text-[var(--c-text-dim)]">
                   {user.platform_role === "ADMIN" ? "Platform admin" : "Room user"} ·{" "}
                   {user.game_role === "GAMEMASTER" ? "Gamemaster" : "Player"}
@@ -97,21 +95,21 @@ export function AuthLanding({ user, onLogout, isLoggingOut }: AuthLandingProps) 
                   Manage access
                 </Link>
               ) : null}
-              <p className="text-xs text-[var(--c-text-faint)]">Your room token is minted from this backend session.</p>
+              <p className="text-xs text-[var(--c-text-faint)]">All set. Join when you're ready.</p>
             </div>
           </section>
         ) : (
           <section className="border border-[var(--c-rule)] bg-[linear-gradient(180deg,rgba(20,26,31,0.96),rgba(8,9,11,0.96))] p-6 shadow-[0_20px_60px_rgba(0,0,0,0.35)]">
             <p className="text-[10px] uppercase tracking-[0.12em] text-[var(--c-text-faint)]">Sign in first</p>
-            <h2 className="display-face mt-2 text-2xl text-[var(--c-text-warm)]">Enter through Google</h2>
+            <h2 className="display-face mt-2 text-2xl text-[var(--c-text-warm)]">Use your game account</h2>
             <p className="mt-3 text-sm leading-6 text-[var(--c-text-dim)]">
-              The backend checks whether your exact email is allowed before it issues any room token.
+              Sign in with the Google account we added for the game.
             </p>
             <a className="chip mt-8 w-full justify-center py-3 text-xs" href={loginHref}>
               Continue with Google
             </a>
             <p className="mt-4 text-xs text-[var(--c-text-faint)]">
-              If this account should be allowed, ask an admin to add it in the access list.
+              If it doesn't let you in, ping the GM or whoever manages access.
             </p>
           </section>
         )}


### PR DESCRIPTION
## Summary
- Replaced the technical landing-page pitch with a short private-game-night hello message
- Simplified feature blurbs around the room, whispers, and GM spotlight
- Reworded sign-in and join-form helper text so it speaks to the handful of expected players instead of explaining backend architecture

## Test plan
- `pnpm --filter frontend test -- --run`
- `pnpm --filter frontend typecheck`
- `pnpm --filter frontend lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated join form copy with new "Almost there / Join the room" messaging replacing previous "Enter the room" wording and updated guidance text
  * Enhanced authentication landing page including revised hero section with new feature descriptions ("Same room", "Whispers", "GM spotlight"), clearer sign-in and join instructions, and confirmation messages for signed-in users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->