### PR TITLE
fix(deps): bump undici audit override

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,21 @@
           "CVE-2026-1527",
           "CVE-2026-2229",
           "CVE-2026-1526",
+          "GHSA-vrm6-8vpv-qv8q",
+          "CVE-2026-9697",
           "GHSA-vmh5-mc38-953g",
+          "CVE-2026-12151",
           "GHSA-vxpw-j846-p89q",
-          "GHSA-hm92-r4w5-c3mj"
+          "CVE-2026-6734",
+          "GHSA-hm92-r4w5-c3mj",
+          "CVE-2026-9678",
+          "GHSA-pr7r-676h-xcf6",
+          "CVE-2026-9679",
+          "GHSA-p88m-4jfj-68fv",
+          "CVE-2026-11525",
+          "GHSA-g8m3-5g58-fq7m",
+          "CVE-2026-6733",
+          "GHSA-35p6-xmwp-9g52"
         ],
         "reference": "https://github.com/nodejs/undici/releases/tag/v7.28.0",
         "note": "Pinned for the current audit cleanup. Keep this override until transitive consumers, currently frontend > jsdom, accept a patched undici without forcing the override."

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "pnpm": {
     "overrides": {
-      "undici": "7.24.0",
+      "undici": "7.28.0",
       "flatted": "3.4.2",
       "picomatch@^4.0.0": "4.0.4",
       "fast-uri": "3.1.2",
@@ -31,10 +31,13 @@
           "CVE-2026-2581",
           "CVE-2026-1527",
           "CVE-2026-2229",
-          "CVE-2026-1526"
+          "CVE-2026-1526",
+          "GHSA-vmh5-mc38-953g",
+          "GHSA-vxpw-j846-p89q",
+          "GHSA-hm92-r4w5-c3mj"
         ],
-        "reference": "https://github.com/nodejs/undici/releases/tag/v7.24.0",
-        "note": "Pinned for the current audit cleanup. Undici v7.24.2 is available for reviewer verification or follow-up adoption if acceptable."
+        "reference": "https://github.com/nodejs/undici/releases/tag/v7.28.0",
+        "note": "Pinned for the current audit cleanup. Keep this override until transitive consumers, currently frontend > jsdom, accept a patched undici without forcing the override."
       },
       "fast-uri": {
         "mitigates": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  undici: 7.24.0
+  undici: 7.28.0
   flatted: 3.4.2
   picomatch@^4.0.0: 4.0.4
   fast-uri: 3.1.2
@@ -1919,8 +1919,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.24.0:
-    resolution: {integrity: sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unplugin@3.0.0:
@@ -3416,7 +3416,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -3871,7 +3871,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.24.0: {}
+  undici@7.28.0: {}
 
   unplugin@3.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Bump the root `undici` override from 7.24.0 to 7.28.0 to satisfy the new patched range for GHSA-vmh5-mc38-953g, GHSA-vxpw-j846-p89q, and GHSA-hm92-r4w5-c3mj.
- Refresh `pnpm-lock.yaml` so the `frontend > jsdom > undici` transitive path resolves to 7.28.0.
- Update the dependency review note to document the new advisories and keep the override rationale current.

Fixes #150

## Verification
- `pnpm audit --audit-level high` — pass, no known vulnerabilities found
- `pnpm lint` — pass (docker compose config emitted expected missing-secret warnings)
- `pnpm test` — pass
- `pnpm typecheck` — pass
- `pnpm build` — blocked locally by docker socket permission in `infrastructure:build`
- `pnpm --filter frontend build` — pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated undici dependency to version 7.28.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->