### PR TITLE
refactor(backend): extract API error boundary

### DIFF
--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -1,0 +1,59 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub(crate) enum ApiError {
+    #[error("not authenticated")]
+    Unauthenticated,
+    #[error("room is not allowed: {0}")]
+    RoomNotAllowed(String),
+    #[error("{0}")]
+    Forbidden(String),
+    #[error("{0}")]
+    Conflict(String),
+    #[error("{0}")]
+    NotFound(String),
+    #[error("bad request: {0}")]
+    BadRequest(String),
+    #[error("internal error")]
+    Internal,
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let (status, code, message) = match self {
+            ApiError::Unauthenticated => (
+                StatusCode::UNAUTHORIZED,
+                "UNAUTHENTICATED",
+                "authentication required".to_string(),
+            ),
+            ApiError::RoomNotAllowed(_) => {
+                (StatusCode::FORBIDDEN, "ROOM_NOT_ALLOWED", self.to_string())
+            }
+            ApiError::Forbidden(_) => (StatusCode::FORBIDDEN, "FORBIDDEN", self.to_string()),
+            ApiError::Conflict(_) => (StatusCode::CONFLICT, "CONFLICT", self.to_string()),
+            ApiError::NotFound(_) => (StatusCode::NOT_FOUND, "NOT_FOUND", self.to_string()),
+            ApiError::BadRequest(_) => (StatusCode::BAD_REQUEST, "BAD_REQUEST", self.to_string()),
+            ApiError::Internal => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL",
+                "unexpected server error".to_string(),
+            ),
+        };
+
+        (
+            status,
+            Json(serde_json::json!({
+                "error": {
+                    "code": code,
+                    "message": message,
+                }
+            })),
+        )
+            .into_response()
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,4 +1,5 @@
 mod config;
+mod error;
 mod users;
 
 use axum::{
@@ -7,7 +8,7 @@ use axum::{
         header::{ACCEPT, CONTENT_TYPE},
         HeaderValue, Method, StatusCode,
     },
-    response::{IntoResponse, Redirect, Response},
+    response::{IntoResponse, Redirect},
     routing::{get, patch, post},
     Json, Router,
 };
@@ -15,6 +16,7 @@ use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use chrono::{DateTime, Duration, Utc};
 use config::AppConfig;
+use error::ApiError;
 use hmac::{Hmac, KeyInit, Mac};
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use rand::{rngs::SysRng, TryRng};
@@ -22,7 +24,6 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{net::SocketAddr, sync::Arc, time::Duration as StdDuration};
-use thiserror::Error;
 use tower_http::{
     cors::{AllowOrigin, Any, CorsLayer},
     trace::TraceLayer,
@@ -1015,59 +1016,6 @@ struct GoogleUserInfo {
     email: String,
     email_verified: bool,
     name: Option<String>,
-}
-
-#[derive(Debug, Error)]
-enum ApiError {
-    #[error("not authenticated")]
-    Unauthenticated,
-    #[error("room is not allowed: {0}")]
-    RoomNotAllowed(String),
-    #[error("{0}")]
-    Forbidden(String),
-    #[error("{0}")]
-    Conflict(String),
-    #[error("{0}")]
-    NotFound(String),
-    #[error("bad request: {0}")]
-    BadRequest(String),
-    #[error("internal error")]
-    Internal,
-}
-
-impl IntoResponse for ApiError {
-    fn into_response(self) -> Response {
-        let (status, code, message) = match self {
-            ApiError::Unauthenticated => (
-                StatusCode::UNAUTHORIZED,
-                "UNAUTHENTICATED",
-                "authentication required".to_string(),
-            ),
-            ApiError::RoomNotAllowed(_) => {
-                (StatusCode::FORBIDDEN, "ROOM_NOT_ALLOWED", self.to_string())
-            }
-            ApiError::Forbidden(_) => (StatusCode::FORBIDDEN, "FORBIDDEN", self.to_string()),
-            ApiError::Conflict(_) => (StatusCode::CONFLICT, "CONFLICT", self.to_string()),
-            ApiError::NotFound(_) => (StatusCode::NOT_FOUND, "NOT_FOUND", self.to_string()),
-            ApiError::BadRequest(_) => (StatusCode::BAD_REQUEST, "BAD_REQUEST", self.to_string()),
-            ApiError::Internal => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "INTERNAL",
-                "unexpected server error".to_string(),
-            ),
-        };
-
-        (
-            status,
-            Json(serde_json::json!({
-                "error": {
-                    "code": code,
-                    "message": message,
-                }
-            })),
-        )
-            .into_response()
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Refs #162

## Summary
- Extracted backend `ApiError` and HTTP error-response mapping into `backend/src/error.rs`.
- Left route behavior and JSON error shape unchanged while reducing `main.rs` boundary responsibilities.

## Validation
- `cargo fmt --manifest-path backend/Cargo.toml -- --check`
- `cargo test --manifest-path backend/Cargo.toml`

## Notes
This is a conservative slice of the broader backend handler extraction; auth/session/admin route modules remain as follow-up work under #162.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error responses with consistent HTTP status codes and clearer JSON error details.
  * Standardized handling for authentication, authorization, not found, bad request, conflict, and internal errors.

* **Refactor**
  * Consolidated error handling into a shared backend component for more consistent responses across requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->