### PR TITLE
refactor(backend): extract token boundary

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod error;
+mod token;
 mod users;
 
 use axum::{
@@ -14,16 +15,16 @@ use axum::{
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-use chrono::{DateTime, Duration, Utc};
+use chrono::{Duration, Utc};
 use config::AppConfig;
 use error::ApiError;
 use hmac::{Hmac, KeyInit, Mac};
-use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use rand::{rngs::SysRng, TryRng};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{net::SocketAddr, sync::Arc, time::Duration as StdDuration};
+use token::mint_token;
 use tower_http::{
     cors::{AllowOrigin, Any, CorsLayer},
     trace::TraceLayer,
@@ -476,72 +477,6 @@ async fn delete_admin_user(
     Ok(StatusCode::NO_CONTENT)
 }
 
-async fn mint_token(
-    State(state): State<Arc<AppState>>,
-    jar: CookieJar,
-    Json(req): Json<TokenRequest>,
-) -> Result<impl IntoResponse, ApiError> {
-    req.validate()?;
-    let user = require_authenticated(&state, &jar).await?;
-
-    if let Some(allowed_rooms) = &state.config.allowed_rooms {
-        if !allowed_rooms.contains(&req.room) {
-            return Err(ApiError::RoomNotAllowed(req.room.clone()));
-        }
-    }
-
-    let google_subject = user.google_subject.clone().ok_or_else(|| {
-        ApiError::Forbidden("authenticated user is missing Google identity".to_string())
-    })?;
-    let opaque_identity = derive_room_identity(&state.config.cookie_secret, &google_subject)?;
-    let nickname = req.name.trim();
-
-    let updated_user = state
-        .user_store
-        .update_user_display_name(user.id, Some(nickname))
-        .await
-        .map_err(|err| {
-            error!("update display name error: {err}");
-            ApiError::Internal
-        })?;
-
-    let now = Utc::now();
-    let expiry = now + Duration::seconds(state.config.token_ttl_seconds as i64);
-
-    let claims = LiveKitClaims {
-        iss: state.config.livekit_api_key.clone(),
-        sub: opaque_identity,
-        name: updated_user
-            .display_name
-            .unwrap_or_else(|| nickname.to_string()),
-        nbf: now.timestamp(),
-        exp: expiry.timestamp(),
-        video: LiveKitVideoGrant {
-            room_join: true,
-            room: req.room,
-            can_publish: true,
-            can_subscribe: true,
-        },
-    };
-
-    let token = encode(
-        &Header::new(Algorithm::HS256),
-        &claims,
-        &EncodingKey::from_secret(state.config.livekit_api_secret.as_bytes()),
-    )
-    .map_err(|_| ApiError::Internal)?;
-
-    Ok((
-        StatusCode::OK,
-        Json(TokenResponse {
-            token,
-            expires_at: expiry,
-            identity: claims.sub,
-            game_role: updated_user.game_role,
-        }),
-    ))
-}
-
 async fn get_authenticated_user(
     state: &AppState,
     jar: &CookieJar,
@@ -562,7 +497,10 @@ async fn get_authenticated_user(
     Ok(user.filter(|value| value.is_active))
 }
 
-async fn require_authenticated(state: &AppState, jar: &CookieJar) -> Result<AuthUser, ApiError> {
+pub(crate) async fn require_authenticated(
+    state: &AppState,
+    jar: &CookieJar,
+) -> Result<AuthUser, ApiError> {
     get_authenticated_user(state, jar)
         .await?
         .ok_or(ApiError::Unauthenticated)
@@ -760,16 +698,6 @@ fn random_token(num_bytes: usize) -> Result<String, ApiError> {
     Ok(URL_SAFE_NO_PAD.encode(bytes))
 }
 
-fn derive_room_identity(secret: &str, google_subject: &str) -> Result<String, ApiError> {
-    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).map_err(|_| ApiError::Internal)?;
-    mac.update(b"livekit-identity:");
-    mac.update(google_subject.as_bytes());
-    Ok(format!(
-        "u_{}",
-        URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes())
-    ))
-}
-
 fn dev_subject_for_email(email: &str) -> String {
     let digest = Sha256::digest(email.as_bytes());
     format!("dev-{}", URL_SAFE_NO_PAD.encode(digest))
@@ -829,40 +757,6 @@ struct DevLoginQuery {
     email: String,
     name: Option<String>,
     next: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct TokenRequest {
-    room: String,
-    name: String,
-}
-
-impl TokenRequest {
-    fn validate(&self) -> Result<(), ApiError> {
-        if self.room.trim().is_empty() {
-            return Err(ApiError::BadRequest("`room` must not be empty".to_string()));
-        }
-
-        let nickname = self.name.trim();
-        if nickname.is_empty() {
-            return Err(ApiError::BadRequest("`name` must not be empty".to_string()));
-        }
-        if nickname.chars().count() > MAX_DISPLAY_NAME_LENGTH {
-            return Err(ApiError::BadRequest(format!(
-                "`name` must be at most {MAX_DISPLAY_NAME_LENGTH} characters"
-            )));
-        }
-
-        Ok(())
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct TokenResponse {
-    token: String,
-    expires_at: DateTime<Utc>,
-    identity: String,
-    game_role: GameRole,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -984,27 +878,6 @@ fn default_true() -> bool {
     true
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct LiveKitClaims {
-    iss: String,
-    sub: String,
-    name: String,
-    nbf: i64,
-    exp: i64,
-    video: LiveKitVideoGrant,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct LiveKitVideoGrant {
-    room: String,
-    #[serde(rename = "roomJoin")]
-    room_join: bool,
-    #[serde(rename = "canPublish")]
-    can_publish: bool,
-    #[serde(rename = "canSubscribe")]
-    can_subscribe: bool,
-}
-
 #[derive(Debug, Deserialize)]
 struct GoogleTokenResponse {
     access_token: String,
@@ -1023,7 +896,8 @@ mod tests {
     use super::*;
     use crate::{config::parse_optional_set, users::build_bootstrap_users};
     use axum::{body::Body, http::Request};
-    use jsonwebtoken::{decode, DecodingKey, Validation};
+    use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+    use token::{derive_room_identity, LiveKitClaims, TokenResponse};
     use tower::ServiceExt;
 
     async fn test_state() -> Arc<AppState> {

--- a/backend/src/token.rs
+++ b/backend/src/token.rs
@@ -1,0 +1,184 @@
+use std::sync::Arc;
+
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use chrono::{DateTime, Duration, Utc};
+use hmac::{Hmac, KeyInit, Mac};
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use tracing::error;
+
+use crate::{
+    error::ApiError, require_authenticated, users::GameRole, AppState, MAX_DISPLAY_NAME_LENGTH,
+};
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct TokenRequest {
+    room: String,
+    name: String,
+}
+
+impl TokenRequest {
+    fn validate(&self) -> Result<(), ApiError> {
+        if self.room.trim().is_empty() {
+            return Err(ApiError::BadRequest("`room` must not be empty".to_string()));
+        }
+
+        let nickname = self.name.trim();
+        if nickname.is_empty() {
+            return Err(ApiError::BadRequest("`name` must not be empty".to_string()));
+        }
+        if nickname.chars().count() > MAX_DISPLAY_NAME_LENGTH {
+            return Err(ApiError::BadRequest(format!(
+                "`name` must be at most {MAX_DISPLAY_NAME_LENGTH} characters"
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct TokenResponse {
+    pub(crate) token: String,
+    pub(crate) expires_at: DateTime<Utc>,
+    pub(crate) identity: String,
+    pub(crate) game_role: GameRole,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct LiveKitClaims {
+    pub(crate) iss: String,
+    pub(crate) sub: String,
+    pub(crate) name: String,
+    pub(crate) nbf: i64,
+    pub(crate) exp: i64,
+    pub(crate) video: LiveKitVideoGrant,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct LiveKitVideoGrant {
+    pub(crate) room: String,
+    #[serde(rename = "roomJoin")]
+    pub(crate) room_join: bool,
+    #[serde(rename = "canPublish")]
+    pub(crate) can_publish: bool,
+    #[serde(rename = "canSubscribe")]
+    pub(crate) can_subscribe: bool,
+}
+
+pub(crate) async fn mint_token(
+    State(state): State<Arc<AppState>>,
+    jar: axum_extra::extract::cookie::CookieJar,
+    Json(req): Json<TokenRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    req.validate()?;
+    let user = require_authenticated(&state, &jar).await?;
+
+    if let Some(allowed_rooms) = &state.config.allowed_rooms {
+        if !allowed_rooms.contains(&req.room) {
+            return Err(ApiError::RoomNotAllowed(req.room.clone()));
+        }
+    }
+
+    let google_subject = user.google_subject.clone().ok_or_else(|| {
+        ApiError::Forbidden("authenticated user is missing Google identity".to_string())
+    })?;
+    let opaque_identity = derive_room_identity(&state.config.cookie_secret, &google_subject)?;
+    let nickname = req.name.trim();
+
+    let updated_user = state
+        .user_store
+        .update_user_display_name(user.id, Some(nickname))
+        .await
+        .map_err(|err| {
+            error!("update display name error: {err}");
+            ApiError::Internal
+        })?;
+
+    let now = Utc::now();
+    let expiry = now + Duration::seconds(state.config.token_ttl_seconds as i64);
+
+    let claims = LiveKitClaims {
+        iss: state.config.livekit_api_key.clone(),
+        sub: opaque_identity,
+        name: updated_user
+            .display_name
+            .unwrap_or_else(|| nickname.to_string()),
+        nbf: now.timestamp(),
+        exp: expiry.timestamp(),
+        video: LiveKitVideoGrant {
+            room_join: true,
+            room: req.room,
+            can_publish: true,
+            can_subscribe: true,
+        },
+    };
+
+    let token = encode(
+        &Header::new(Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(state.config.livekit_api_secret.as_bytes()),
+    )
+    .map_err(|_| ApiError::Internal)?;
+
+    Ok((
+        StatusCode::OK,
+        Json(TokenResponse {
+            token,
+            expires_at: expiry,
+            identity: claims.sub,
+            game_role: updated_user.game_role,
+        }),
+    ))
+}
+
+pub(crate) fn derive_room_identity(secret: &str, google_subject: &str) -> Result<String, ApiError> {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).map_err(|_| ApiError::Internal)?;
+    mac.update(b"livekit-identity:");
+    mac.update(google_subject.as_bytes());
+    Ok(format!(
+        "u_{}",
+        URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes())
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_request_rejects_empty_room_or_name() {
+        assert!(matches!(
+            TokenRequest {
+                room: " ".to_string(),
+                name: "Alice".to_string(),
+            }
+            .validate(),
+            Err(ApiError::BadRequest(_))
+        ));
+        assert!(matches!(
+            TokenRequest {
+                room: "table".to_string(),
+                name: " ".to_string(),
+            }
+            .validate(),
+            Err(ApiError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn room_identity_is_stable_and_opaque() {
+        let first = derive_room_identity("secret", "google-subject").unwrap();
+        let second = derive_room_identity("secret", "google-subject").unwrap();
+        let different_subject = derive_room_identity("secret", "other-subject").unwrap();
+
+        assert_eq!(first, second);
+        assert_ne!(first, different_subject);
+        assert!(first.starts_with("u_"));
+        assert!(!first.contains("google-subject"));
+    }
+}

--- a/backend/src/token.rs
+++ b/backend/src/token.rs
@@ -100,7 +100,7 @@ pub(crate) async fn mint_token(
         })?;
 
     let now = Utc::now();
-    let expiry = now + Duration::seconds(state.config.token_ttl_seconds as i64);
+    let expiry = token_expiry(now, state.config.token_ttl_seconds)?;
 
     let claims = LiveKitClaims {
         iss: state.config.livekit_api_key.clone(),
@@ -146,6 +146,21 @@ pub(crate) fn derive_room_identity(secret: &str, google_subject: &str) -> Result
     ))
 }
 
+fn token_expiry(now: DateTime<Utc>, token_ttl_seconds: u64) -> Result<DateTime<Utc>, ApiError> {
+    let ttl_seconds = i64::try_from(token_ttl_seconds).map_err(|err| {
+        error!("token TTL exceeds supported duration range: {err}");
+        ApiError::Internal
+    })?;
+    let ttl = Duration::try_seconds(ttl_seconds).ok_or_else(|| {
+        error!("token TTL exceeds supported duration range");
+        ApiError::Internal
+    })?;
+    now.checked_add_signed(ttl).ok_or_else(|| {
+        error!("token TTL would produce an unsupported expiry timestamp");
+        ApiError::Internal
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -180,5 +195,19 @@ mod tests {
         assert_ne!(first, different_subject);
         assert!(first.starts_with("u_"));
         assert!(!first.contains("google-subject"));
+    }
+
+    #[test]
+    fn token_expiry_rejects_oversized_ttl() {
+        let now = DateTime::<Utc>::from_timestamp(0, 0).unwrap();
+
+        assert_eq!(
+            token_expiry(now, 3_600).unwrap(),
+            DateTime::<Utc>::from_timestamp(3_600, 0).unwrap()
+        );
+        assert!(matches!(
+            token_expiry(now, i64::MAX as u64 + 1),
+            Err(ApiError::Internal)
+        ));
     }
 }


### PR DESCRIPTION
Refs #162

## Summary
- Extracted LiveKit token request validation, JWT claim construction, and room identity derivation into `backend/src/token.rs`.
- Kept `/api/v1/token` route behavior and JSON response shape unchanged.
- Added focused unit coverage for token request validation and opaque/stable identity derivation at the new module boundary.

## Validation
- `cargo fmt --manifest-path backend/Cargo.toml -- --check`
- `cargo clippy --manifest-path backend/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path backend/Cargo.toml`

## Notes
This is one behavior-preserving slice of #162. Remaining slices include extracting route registration, auth/session handlers, and admin user handlers/DTOs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for minting LiveKit access tokens for authenticated users.
  * Token responses now include the token, expiration time, room identity, and game role.
  * Display names are updated from token requests, and room access can be limited by allowed rooms.

* **Bug Fixes**
  * Strengthened token request validation to reject invalid room names and overly long display names.
  * Improved room identity generation to keep identities stable and opaque.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->