### PR TITLE
refactor(room-session): model device panel props

### DIFF
--- a/frontend/src/features/room-session/components/DevicePanel.tsx
+++ b/frontend/src/features/room-session/components/DevicePanel.tsx
@@ -1,25 +1,14 @@
 import { useState } from "react";
+import type { DevicePanelActions, DevicePanelViewModel } from "@/features/room-session/types";
 
 type DevicePanelProps = {
-  audioDevices: MediaDeviceInfo[];
-  videoDevices: MediaDeviceInfo[];
-  selectedAudioDevice: string;
-  selectedVideoDevice: string;
-  mirrorSelfView: boolean;
-  onMirrorSelfViewChange: (mirrored: boolean) => void;
-  onSelectAudioDevice: (deviceId: string) => Promise<void>;
-  onSelectVideoDevice: (deviceId: string) => Promise<void>;
+  model: DevicePanelViewModel;
+  actions: DevicePanelActions;
 };
 
 export function DevicePanel({
-  audioDevices,
-  videoDevices,
-  selectedAudioDevice,
-  selectedVideoDevice,
-  mirrorSelfView,
-  onMirrorSelfViewChange,
-  onSelectAudioDevice,
-  onSelectVideoDevice
+  model: { audioDevices, videoDevices, selectedAudioDevice, selectedVideoDevice, mirrorSelfView },
+  actions: { onMirrorSelfViewChange, onSelectAudioDevice, onSelectVideoDevice }
 }: DevicePanelProps) {
   const [deviceError, setDeviceError] = useState<string | null>(null);
 

--- a/frontend/src/features/room-session/components/RoomSessionController.tsx
+++ b/frontend/src/features/room-session/components/RoomSessionController.tsx
@@ -286,14 +286,18 @@ export function RoomSessionController({ roomName, displayName }: RoomSessionCont
           }
           devicePanel={
             <DevicePanel
-              audioDevices={media.audioDevices}
-              videoDevices={media.videoDevices}
-              selectedAudioDevice={media.selectedAudioDevice}
-              selectedVideoDevice={media.selectedVideoDevice}
-              mirrorSelfView={media.mirrorSelfView}
-              onMirrorSelfViewChange={media.onMirrorSelfViewChange}
-              onSelectAudioDevice={media.onSelectAudioDevice}
-              onSelectVideoDevice={media.onSelectVideoDevice}
+              model={{
+                audioDevices: media.audioDevices,
+                videoDevices: media.videoDevices,
+                selectedAudioDevice: media.selectedAudioDevice,
+                selectedVideoDevice: media.selectedVideoDevice,
+                mirrorSelfView: media.mirrorSelfView
+              }}
+              actions={{
+                onMirrorSelfViewChange: media.onMirrorSelfViewChange,
+                onSelectAudioDevice: media.onSelectAudioDevice,
+                onSelectVideoDevice: media.onSelectVideoDevice
+              }}
             />
           }
         />

--- a/frontend/src/features/room-session/types.ts
+++ b/frontend/src/features/room-session/types.ts
@@ -49,3 +49,17 @@ export type WhisperPanelState = {
   isPttActive: boolean;
   identity: string;
 };
+
+export type DevicePanelViewModel = {
+  audioDevices: ReadonlyArray<MediaDeviceInfo>;
+  videoDevices: ReadonlyArray<MediaDeviceInfo>;
+  selectedAudioDevice: string;
+  selectedVideoDevice: string;
+  mirrorSelfView: boolean;
+};
+
+export type DevicePanelActions = {
+  onMirrorSelfViewChange: (mirrored: boolean) => void;
+  onSelectAudioDevice: (deviceId: string) => Promise<void>;
+  onSelectVideoDevice: (deviceId: string) => Promise<void>;
+};


### PR DESCRIPTION
Refs #136

## Summary
- add explicit `DevicePanelViewModel` and `DevicePanelActions` contracts for the room-session device panel
- update `DevicePanel` to accept display data separately from commands/mutations
- update `RoomSessionController` to construct the cohesive panel model at the call site

## Validation
- `npm exec --yes pnpm@10.30.3 -- --filter frontend typecheck`
- `npm exec --yes pnpm@10.30.3 -- --filter frontend lint`
- `npm exec --yes pnpm@10.30.3 -- --filter frontend test`

## Notes
This is a behavior-preserving slice of #136. It starts with the smallest panel boundary; remaining slices can apply the same pattern to top bar, whisper, and split control panels.
