### PR TITLE
refactor(room-session): introduce focused view models

### DIFF
--- a/frontend/src/features/room-session/components/RoomSessionController.tsx
+++ b/frontend/src/features/room-session/components/RoomSessionController.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo, useState } from "react";
 import { DevicePanel } from "@/features/room-session/components/DevicePanel";
 import { ParticipantRoster } from "@/features/room-session/components/ParticipantRoster";
 import { RemoteAudioLayer } from "@/features/room-session/components/RemoteAudioLayer";
@@ -12,22 +11,7 @@ import { SplitControlPanel } from "@/features/room-session/components/SplitContr
 import { SplitStatusPanel } from "@/features/room-session/components/SplitStatusPanel";
 import { VideoGrid } from "@/features/room-session/components/VideoGrid";
 import { WhisperPanel } from "@/features/room-session/components/WhisperPanel";
-import { useRoomConnection } from "@/features/room-session/hooks/useRoomConnection";
-import { useRoomMedia } from "@/features/room-session/hooks/useRoomMedia";
-import { useRoomParticipants } from "@/features/room-session/hooks/useRoomParticipants";
-import { useSplitRoomSession } from "@/features/room-session/hooks/useSplitRoomSession";
-import { useWhisperSession } from "@/features/room-session/hooks/useWhisperSession";
-import {
-  buildAudioTracks,
-  buildParticipantRoster,
-  buildVideoTiles,
-  filterAudioTracksForSplitView,
-  filterParticipantIdentitiesForSplitView,
-  filterVideoTilesForSplitView,
-  orderGridTiles,
-  resolveParticipantLabel,
-  resolveParticipantRoomId
-} from "@/features/room-session/lib/session-selectors";
+import { useRoomSessionViewModel } from "@/features/room-session/hooks/useRoomSessionViewModel";
 
 type RoomSessionControllerProps = {
   roomName: string;
@@ -35,274 +19,51 @@ type RoomSessionControllerProps = {
 };
 
 export function RoomSessionController({ roomName, displayName }: RoomSessionControllerProps) {
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const viewModel = useRoomSessionViewModel({ roomName, displayName });
 
-  const connection = useRoomConnection({ roomName, displayName });
-  const media = useRoomMedia({ room: connection.room });
-  const { participantDisplayNames, participantIdentities } = useRoomParticipants({
-    room: connection.room,
-    identity: connection.identity,
-    renderVersion: connection.renderVersion,
-    displayName
-  });
-  const splitSession = useSplitRoomSession({
-    room: connection.room,
-    identity: connection.identity,
-    gameRole: connection.gameRole,
-    participantIdentities
-  });
-  const whisperSession = useWhisperSession({
-    room: connection.room,
-    identity: connection.identity,
-    renderVersion: connection.renderVersion,
-    splitState: splitSession.splitState,
-    viewerIsGamemaster: splitSession.viewerIsGamemaster,
-    startWhisperPtt: media.startWhisperPtt,
-    stopWhisperPtt: media.stopWhisperPtt,
-    clearWhisperTrack: media.clearWhisperTrack
-  });
-
-  const isConnecting = connection.isConnecting || media.isInitializing;
-  const error = connection.error ?? media.error;
-
-  const visibleParticipantIdentities = useMemo(
-    () =>
-      filterParticipantIdentitiesForSplitView(participantIdentities, {
-        splitState: splitSession.splitState,
-        viewerIdentity: connection.identity,
-        viewerIsGamemaster: splitSession.viewerIsGamemaster
-      }),
-    [connection.identity, participantIdentities, splitSession.splitState, splitSession.viewerIsGamemaster]
-  );
-
-  const videoTiles = useMemo(
-    () => {
-      const version = connection.renderVersion;
-      void version;
-
-      return buildVideoTiles(
-        connection.room,
-        connection.identity,
-        whisperSession.followSpotlight,
-        whisperSession.spotlightIdentity
-      );
-    },
-    [
-      connection.identity,
-      connection.renderVersion,
-      connection.room,
-      whisperSession.followSpotlight,
-      whisperSession.spotlightIdentity
-    ]
-  );
-
-  const visibleVideoTiles = useMemo(
-    () =>
-      filterVideoTilesForSplitView(videoTiles, {
-        splitState: splitSession.splitState,
-        viewerIdentity: connection.identity,
-        viewerIsGamemaster: splitSession.viewerIsGamemaster
-      }),
-    [connection.identity, splitSession.splitState, splitSession.viewerIsGamemaster, videoTiles]
-  );
-
-  const audioTracks = useMemo(
-    () => {
-      const version = connection.renderVersion;
-      void version;
-
-      return buildAudioTracks(connection.room);
-    },
-    [connection.renderVersion, connection.room]
-  );
-
-  const visibleAudioTracks = useMemo(
-    () =>
-      filterAudioTracksForSplitView(audioTracks, {
-        splitState: splitSession.splitState,
-        viewerIdentity: connection.identity,
-        viewerIsGamemaster: splitSession.viewerIsGamemaster
-      }),
-    [audioTracks, connection.identity, splitSession.splitState, splitSession.viewerIsGamemaster]
-  );
-
-  const participantRoster = useMemo(
-    () =>
-      buildParticipantRoster({
-        participantIdentities: visibleParticipantIdentities,
-        participantDisplayNames,
-        identity: connection.identity,
-        activeSpeakers: connection.activeSpeakers,
-        videoTiles: visibleVideoTiles,
-        activeWhispers: whisperSession.activeWhispers,
-        spotlightIdentity: whisperSession.spotlightIdentity
-      }),
-    [
-      connection.activeSpeakers,
-      connection.identity,
-      participantDisplayNames,
-      visibleParticipantIdentities,
-      visibleVideoTiles,
-      whisperSession.activeWhispers,
-      whisperSession.spotlightIdentity
-    ]
-  );
-
-  const gridTiles = useMemo(
-    () => orderGridTiles(visibleVideoTiles, whisperSession.spotlightIdentity),
-    [visibleVideoTiles, whisperSession.spotlightIdentity]
-  );
-  const splitParticipants = useMemo(
-    () =>
-      participantIdentities
-        .map((participantIdentity) => ({
-          identity: participantIdentity,
-          label: resolveParticipantLabel(participantIdentity, participantDisplayNames),
-          isLocal: participantIdentity === connection.identity,
-          roomId: resolveParticipantRoomId(splitSession.splitState, participantIdentity)
-        }))
-        .sort((left, right) => {
-          if (left.identity === splitSession.splitState.gmIdentity && right.identity !== splitSession.splitState.gmIdentity) {
-            return -1;
-          }
-          if (right.identity === splitSession.splitState.gmIdentity && left.identity !== splitSession.splitState.gmIdentity) {
-            return 1;
-          }
-          if (left.isLocal && !right.isLocal) {
-            return -1;
-          }
-          if (right.isLocal && !left.isLocal) {
-            return 1;
-          }
-          if (left.roomId !== right.roomId) {
-            return left.roomId.localeCompare(right.roomId);
-          }
-          return left.label.localeCompare(right.label);
-        }),
-    [connection.identity, participantDisplayNames, participantIdentities, splitSession.splitState]
-  );
-  const splitPanel =
-    splitSession.canManageSplitRooms || splitSession.isActive || splitSession.notice ? (
-      <>
-        {splitSession.canManageSplitRooms ? (
-          <SplitControlPanel
-            splitState={splitSession.splitState}
-            participants={splitParticipants}
-            isPublishingCommand={splitSession.isPublishingCommand}
-            commandError={splitSession.commandError}
-            onStartSplit={splitSession.startSplit}
-            onAddRoom={splitSession.addRoom}
-            onRemoveRoom={splitSession.removeRoom}
-            onRenameRoom={splitSession.renameRoom}
-            onAssignParticipantToRoom={splitSession.assignParticipantToRoom}
-            onSetGmFocusRoom={splitSession.setGmFocusRoom}
-            onSetGmBroadcastActive={splitSession.setGmBroadcastActive}
-            onEndSplit={splitSession.endSplit}
-          />
-        ) : null}
-        <SplitStatusPanel
-          isActive={splitSession.isActive}
-          currentRoomName={splitSession.currentRoomName}
-          participantCount={participantRoster.length}
-          notice={splitSession.notice}
-        />
-      </>
-    ) : undefined;
-
-  if (isConnecting) {
+  if (viewModel.status.isConnecting) {
     return <RoomSessionState title="Entering the table" message="Connecting to room..." />;
   }
 
-  if (error) {
-    return <RoomSessionState title="Connection Failed" message={error} tone="error" />;
+  if (viewModel.status.error) {
+    return <RoomSessionState title="Connection Failed" message={viewModel.status.error} tone="error" />;
   }
 
-  if (!connection.room) {
+  if (!viewModel.status.isConnected) {
     return <RoomSessionState message="Room is not connected." />;
   }
 
+  const splitPanel = viewModel.sidebar.splitPanelVisible ? (
+    <>
+      {viewModel.sidebar.splitControl ? <SplitControlPanel {...viewModel.sidebar.splitControl} /> : null}
+      <SplitStatusPanel {...viewModel.sidebar.splitStatus} />
+    </>
+  ) : undefined;
+
   return (
     <RoomSessionLayout
-      header={
-        <RoomTopBar
-          roomName={roomName}
-          displayName={displayName}
-          identity={connection.identity}
-          participantCount={participantRoster.length}
-          activeWhisperCount={whisperSession.activeWhispers.length}
-          currentRoomName={splitSession.currentRoomName}
-          splitActive={splitSession.isActive}
-          spotlightIdentity={whisperSession.spotlightIdentity}
-          micEnabled={media.micEnabled}
-          cameraEnabled={media.cameraEnabled}
-          followSpotlight={whisperSession.followSpotlight}
-          sidebarOpen={sidebarOpen}
-          onToggleMic={media.toggleMic}
-          onToggleCamera={media.toggleCamera}
-          onFollowSpotlightChange={whisperSession.setFollowSpotlight}
-          onToggleSidebar={() => setSidebarOpen((current) => !current)}
-          onLeave={connection.disconnect}
-        />
-      }
-      main={
-        <VideoGrid
-          gridTiles={gridTiles}
-          gridCount={Math.min(gridTiles.length, 12)}
-          spotlightIdentity={whisperSession.spotlightIdentity}
-          activeSpeakers={connection.activeSpeakers}
-          participantDisplayNames={participantDisplayNames}
-          selectedParticipantIds={whisperSession.selectedParticipantIds}
-          mirrorSelfView={media.mirrorSelfView}
-          onToggleParticipantSelection={whisperSession.toggleParticipantSelection}
-          onToggleSpotlight={whisperSession.setSpotlight}
-        />
-      }
+      header={<RoomTopBar {...viewModel.topBar} />}
+      main={<VideoGrid {...viewModel.videoGrid} />}
       sidebar={
         <SessionSidebar
-          open={sidebarOpen}
+          open={viewModel.sidebar.open}
           splitPanel={splitPanel}
-          whisperPanel={
-            <WhisperPanel
-              activeWhispers={whisperSession.activeWhispers}
-              selectedWhisperId={whisperSession.selectedWhisperId}
-              selectedWhisper={whisperSession.selectedWhisper}
-              selectedParticipants={whisperSession.selectedParticipants}
-              whisperNotice={whisperSession.whisperNotice}
-              isPttActive={media.isPttActive}
-              identity={connection.identity}
-              onCreateWhisper={whisperSession.createWhisper}
-              onSelectWhisper={whisperSession.setSelectedWhisperId}
-              onJoinWhisper={whisperSession.joinWhisper}
-              onAddSelectedParticipants={whisperSession.addSelectedParticipantsToWhisper}
-              onLeaveWhisper={whisperSession.leaveWhisper}
-              onCloseWhisper={whisperSession.closeWhisper}
-            />
-          }
+          whisperPanel={<WhisperPanel {...viewModel.sidebar.whisperPanel} />}
           rosterPanel={
             <ParticipantRoster
-              participantRoster={participantRoster}
-              title={splitSession.isActive ? "IN ROOM" : "AT TABLE"}
+              participantRoster={viewModel.sidebar.participantRoster.items}
+              title={viewModel.sidebar.participantRoster.title}
             />
           }
-          devicePanel={
-            <DevicePanel
-              model={{
-                audioDevices: media.audioDevices,
-                videoDevices: media.videoDevices,
-                selectedAudioDevice: media.selectedAudioDevice,
-                selectedVideoDevice: media.selectedVideoDevice,
-                mirrorSelfView: media.mirrorSelfView
-              }}
-              actions={{
-                onMirrorSelfViewChange: media.onMirrorSelfViewChange,
-                onSelectAudioDevice: media.onSelectAudioDevice,
-                onSelectVideoDevice: media.onSelectVideoDevice
-              }}
-            />
-          }
+          devicePanel={<DevicePanel {...viewModel.sidebar.devicePanel} />}
         />
       }
-      audioLayer={<RemoteAudioLayer audioTracks={visibleAudioTracks} mainVolume={whisperSession.mainVolume} />}
+      audioLayer={
+        <RemoteAudioLayer
+          audioTracks={viewModel.audioLayer.tracks}
+          mainVolume={viewModel.audioLayer.mainVolume}
+        />
+      }
     />
   );
 }

--- a/frontend/src/features/room-session/components/RoomTopBar.tsx
+++ b/frontend/src/features/room-session/components/RoomTopBar.tsx
@@ -1,35 +1,27 @@
 import { formatIdentityLabel } from "@/features/room-session/lib/session-helpers";
-import type { RoomSessionControls } from "@/features/room-session/types";
+import type { RoomTopBarActions, RoomTopBarViewModel } from "@/features/room-session/types";
 
-type RoomTopBarProps = RoomSessionControls & {
-  roomName: string;
-  displayName: string;
-  identity: string;
-  participantCount: number;
-  activeWhisperCount: number;
-  currentRoomName?: string;
-  splitActive: boolean;
-  spotlightIdentity?: string;
+type RoomTopBarProps = {
+  model: RoomTopBarViewModel;
+  actions: RoomTopBarActions;
 };
 
 export function RoomTopBar({
-  roomName,
-  displayName,
-  identity,
-  participantCount,
-  activeWhisperCount,
-  currentRoomName,
-  splitActive,
-  spotlightIdentity,
-  micEnabled,
-  cameraEnabled,
-  followSpotlight,
-  sidebarOpen,
-  onToggleMic,
-  onToggleCamera,
-  onFollowSpotlightChange,
-  onToggleSidebar,
-  onLeave
+  model: {
+    roomName,
+    displayName,
+    identity,
+    participantCount,
+    activeWhisperCount,
+    currentRoomName,
+    splitActive,
+    spotlightIdentity,
+    micEnabled,
+    cameraEnabled,
+    followSpotlight,
+    sidebarOpen
+  },
+  actions: { onToggleMic, onToggleCamera, onFollowSpotlightChange, onToggleSidebar, onLeave }
 }: RoomTopBarProps) {
   return (
     <header className="z-20 flex shrink-0 items-center justify-between gap-6 bg-[var(--c-ink)] px-5 py-2">

--- a/frontend/src/features/room-session/components/SplitControlPanel.tsx
+++ b/frontend/src/features/room-session/components/SplitControlPanel.tsx
@@ -1,38 +1,26 @@
 import { useState } from "react";
 import { SplitParticipantAssignmentRow } from "@/features/room-session/components/SplitParticipantAssignmentRow";
-import type { SplitParticipantOption } from "@/features/room-session/components/SplitParticipantAssignmentRow";
 import { resolveParticipantRoomId } from "@/features/room-session/lib/session-selectors";
 import { canAddSideRoom } from "@/features/room-session/lib/split-room-rules";
-import type { SplitState } from "@/lib/protocol";
+import type { SplitControlPanelActions, SplitControlPanelViewModel } from "@/features/room-session/types";
 
 type SplitControlPanelProps = {
-  splitState: SplitState;
-  participants: SplitParticipantOption[];
-  isPublishingCommand: boolean;
-  commandError: string | null;
-  onStartSplit: () => Promise<boolean>;
-  onAddRoom: () => Promise<boolean>;
-  onRemoveRoom: (roomId: string) => Promise<boolean>;
-  onRenameRoom: (roomId: string, roomName: string) => Promise<boolean>;
-  onAssignParticipantToRoom: (participantIdentity: string, roomId: string) => Promise<boolean>;
-  onSetGmFocusRoom: (roomId: string | null) => Promise<boolean>;
-  onSetGmBroadcastActive: (active: boolean) => Promise<boolean>;
-  onEndSplit: () => Promise<boolean>;
+  model: SplitControlPanelViewModel;
+  actions: SplitControlPanelActions;
 };
 
 export function SplitControlPanel({
-  splitState,
-  participants,
-  isPublishingCommand,
-  commandError,
-  onStartSplit,
-  onAddRoom,
-  onRemoveRoom,
-  onRenameRoom,
-  onAssignParticipantToRoom,
-  onSetGmFocusRoom,
-  onSetGmBroadcastActive,
-  onEndSplit
+  model: { splitState, participants, isPublishingCommand, commandError },
+  actions: {
+    onStartSplit,
+    onAddRoom,
+    onRemoveRoom,
+    onRenameRoom,
+    onAssignParticipantToRoom,
+    onSetGmFocusRoom,
+    onSetGmBroadcastActive,
+    onEndSplit
+  }
 }: SplitControlPanelProps) {
   const [editingRoomId, setEditingRoomId] = useState<string | null>(null);
   const [draftRoomName, setDraftRoomName] = useState("");
@@ -132,8 +120,8 @@ export function SplitControlPanel({
                                 className="act act--gold"
                                 disabled={isPublishingCommand}
                                 onClick={() => {
-                                  void onRenameRoom(room.id, draftRoomName).then((didRename) => {
-                                    if (didRename) {
+                                  void onRenameRoom(room.id, draftRoomName).then((result) => {
+                                    if (result.ok) {
                                       setEditingRoomId(null);
                                       setDraftRoomName("");
                                     }
@@ -213,4 +201,3 @@ export function SplitControlPanel({
     </section>
   );
 }
-

--- a/frontend/src/features/room-session/components/SplitParticipantAssignmentRow.tsx
+++ b/frontend/src/features/room-session/components/SplitParticipantAssignmentRow.tsx
@@ -1,19 +1,14 @@
 import { resolveParticipantRoomId } from "@/features/room-session/lib/session-selectors";
+import type { CommandResult, SplitParticipantOption } from "@/features/room-session/types";
 import type { SplitRoom, SplitState } from "@/lib/protocol";
-
-export type SplitParticipantOption = {
-  identity: string;
-  label: string;
-  isLocal: boolean;
-};
 
 type SplitParticipantAssignmentRowProps = {
   participant: SplitParticipantOption;
-  rooms: SplitRoom[];
+  rooms: ReadonlyArray<SplitRoom>;
   splitState: SplitState;
   disabled: boolean;
   isPinnedToGmRole: boolean;
-  onAssignParticipantToRoom: (participantIdentity: string, roomId: string) => Promise<boolean>;
+  onAssignParticipantToRoom: (participantIdentity: string, roomId: string) => Promise<CommandResult>;
 };
 
 export function SplitParticipantAssignmentRow({

--- a/frontend/src/features/room-session/components/VideoGrid.tsx
+++ b/frontend/src/features/room-session/components/VideoGrid.tsx
@@ -1,29 +1,23 @@
-import type { VideoTileModel } from "@/features/room-session/types";
+import type { VideoGridActions, VideoGridViewModel } from "@/features/room-session/types";
 import { VideoTile } from "@/features/room-session/components/VideoTile";
 import { resolveParticipantLabel } from "@/features/room-session/lib/session-selectors";
 
 type VideoGridProps = {
-  gridTiles: VideoTileModel[];
-  gridCount: number;
-  spotlightIdentity?: string;
-  activeSpeakers: Set<string>;
-  participantDisplayNames: ReadonlyMap<string, string>;
-  selectedParticipantIds: Set<string>;
-  mirrorSelfView: boolean;
-  onToggleParticipantSelection: (participantIdentity: string) => void;
-  onToggleSpotlight: (targetIdentity: string | null) => Promise<void>;
+  model: VideoGridViewModel;
+  actions: VideoGridActions;
 };
 
 export function VideoGrid({
-  gridTiles,
-  gridCount,
-  spotlightIdentity,
-  activeSpeakers,
-  participantDisplayNames,
-  selectedParticipantIds,
-  mirrorSelfView,
-  onToggleParticipantSelection,
-  onToggleSpotlight
+  model: {
+    gridTiles,
+    gridCount,
+    spotlightIdentity,
+    activeSpeakers,
+    participantDisplayNames,
+    selectedParticipantIds,
+    mirrorSelfView
+  },
+  actions: { onToggleParticipantSelection, onToggleSpotlight }
 }: VideoGridProps) {
   return (
     <section className="relative min-w-0 flex-1">

--- a/frontend/src/features/room-session/components/WhisperPanel.tsx
+++ b/frontend/src/features/room-session/components/WhisperPanel.tsx
@@ -1,30 +1,29 @@
-import type { Whisper } from "@/lib/protocol";
-import type { WhisperPanelState } from "@/features/room-session/types";
+import type { WhisperPanelActions, WhisperPanelViewModel } from "@/features/room-session/types";
 import { formatIdentityLabel, getWhisperLabel } from "@/features/room-session/lib/session-helpers";
 
-type WhisperPanelProps = WhisperPanelState & {
-  onCreateWhisper: () => Promise<void>;
-  onSelectWhisper: (whisperId?: string) => void;
-  onJoinWhisper: (whisper: Whisper) => Promise<void>;
-  onAddSelectedParticipants: (whisper: Whisper) => Promise<void>;
-  onLeaveWhisper: (whisper: Whisper) => Promise<void>;
-  onCloseWhisper: (whisper: Whisper) => Promise<void>;
+type WhisperPanelProps = {
+  model: WhisperPanelViewModel;
+  actions: WhisperPanelActions;
 };
 
 export function WhisperPanel({
-  activeWhispers,
-  selectedWhisperId,
-  selectedWhisper,
-  selectedParticipants,
-  whisperNotice,
-  isPttActive,
-  identity,
-  onCreateWhisper,
-  onSelectWhisper,
-  onJoinWhisper,
-  onAddSelectedParticipants,
-  onLeaveWhisper,
-  onCloseWhisper
+  model: {
+    activeWhispers,
+    selectedWhisperId,
+    selectedWhisper,
+    selectedParticipants,
+    whisperNotice,
+    isPttActive,
+    identity
+  },
+  actions: {
+    onCreateWhisper,
+    onSelectWhisper,
+    onJoinWhisper,
+    onAddSelectedParticipants,
+    onLeaveWhisper,
+    onCloseWhisper
+  }
 }: WhisperPanelProps) {
   return (
     <>

--- a/frontend/src/features/room-session/hooks/useRoomSessionViewModel.ts
+++ b/frontend/src/features/room-session/hooks/useRoomSessionViewModel.ts
@@ -1,0 +1,269 @@
+import { useCallback, useMemo, useState } from "react";
+import { useRoomConnection } from "@/features/room-session/hooks/useRoomConnection";
+import { useRoomMedia } from "@/features/room-session/hooks/useRoomMedia";
+import { useRoomParticipants } from "@/features/room-session/hooks/useRoomParticipants";
+import { useSplitRoomSession } from "@/features/room-session/hooks/useSplitRoomSession";
+import { useWhisperSession } from "@/features/room-session/hooks/useWhisperSession";
+import {
+  buildAudioTracks,
+  buildRoomSessionCollections,
+  buildVideoTiles
+} from "@/features/room-session/lib/session-selectors";
+import type {
+  CommandResult,
+  DevicePanelActions,
+  DevicePanelViewModel,
+  RoomTopBarActions,
+  RoomTopBarViewModel,
+  SplitControlPanelActions,
+  SplitControlPanelViewModel,
+  VideoGridActions,
+  VideoGridViewModel,
+  WhisperPanelActions,
+  WhisperPanelViewModel
+} from "@/features/room-session/types";
+
+type UseRoomSessionViewModelInput = {
+  roomName: string;
+  displayName: string;
+};
+
+function commandResult(ok: boolean): CommandResult {
+  return ok ? { ok: true } : { ok: false };
+}
+
+export function useRoomSessionViewModel({ roomName, displayName }: UseRoomSessionViewModelInput) {
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+
+  const connection = useRoomConnection({ roomName, displayName });
+  const media = useRoomMedia({ room: connection.room });
+  const { participantDisplayNames, participantIdentities } = useRoomParticipants({
+    room: connection.room,
+    identity: connection.identity,
+    renderVersion: connection.renderVersion,
+    displayName
+  });
+  const splitSession = useSplitRoomSession({
+    room: connection.room,
+    identity: connection.identity,
+    gameRole: connection.gameRole,
+    participantIdentities
+  });
+  const whisperSession = useWhisperSession({
+    room: connection.room,
+    identity: connection.identity,
+    renderVersion: connection.renderVersion,
+    splitState: splitSession.splitState,
+    viewerIsGamemaster: splitSession.viewerIsGamemaster,
+    startWhisperPtt: media.startWhisperPtt,
+    stopWhisperPtt: media.stopWhisperPtt,
+    clearWhisperTrack: media.clearWhisperTrack
+  });
+
+  const videoTiles = useMemo(() => {
+    const version = connection.renderVersion;
+    void version;
+
+    return buildVideoTiles(
+      connection.room,
+      connection.identity,
+      whisperSession.followSpotlight,
+      whisperSession.spotlightIdentity
+    );
+  }, [
+    connection.identity,
+    connection.renderVersion,
+    connection.room,
+    whisperSession.followSpotlight,
+    whisperSession.spotlightIdentity
+  ]);
+
+  const audioTracks = useMemo(() => {
+    const version = connection.renderVersion;
+    void version;
+
+    return buildAudioTracks(connection.room);
+  }, [connection.renderVersion, connection.room]);
+
+  const collections = useMemo(
+    () =>
+      buildRoomSessionCollections({
+        participantIdentities,
+        participantDisplayNames,
+        viewerIdentity: connection.identity,
+        viewerIsGamemaster: splitSession.viewerIsGamemaster,
+        activeSpeakers: connection.activeSpeakers,
+        videoTiles,
+        audioTracks,
+        activeWhispers: whisperSession.activeWhispers,
+        spotlightIdentity: whisperSession.spotlightIdentity,
+        splitState: splitSession.splitState
+      }),
+    [
+      audioTracks,
+      connection.activeSpeakers,
+      connection.identity,
+      participantDisplayNames,
+      participantIdentities,
+      splitSession.splitState,
+      splitSession.viewerIsGamemaster,
+      videoTiles,
+      whisperSession.activeWhispers,
+      whisperSession.spotlightIdentity
+    ]
+  );
+
+  const toggleSidebar = useCallback(() => setSidebarOpen((current) => !current), []);
+  const {
+    addRoom,
+    assignParticipantToRoom,
+    endSplit,
+    removeRoom,
+    renameRoom,
+    setGmBroadcastActive,
+    setGmFocusRoom,
+    startSplit
+  } = splitSession;
+
+  const splitControlActions = useMemo<SplitControlPanelActions>(
+    () => ({
+      onStartSplit: async () => commandResult(await startSplit()),
+      onAddRoom: async () => commandResult(await addRoom()),
+      onRemoveRoom: async (roomId) => commandResult(await removeRoom(roomId)),
+      onRenameRoom: async (roomId, roomName) => commandResult(await renameRoom(roomId, roomName)),
+      onAssignParticipantToRoom: async (participantIdentity, roomId) =>
+        commandResult(await assignParticipantToRoom(participantIdentity, roomId)),
+      onSetGmFocusRoom: async (roomId) => commandResult(await setGmFocusRoom(roomId)),
+      onSetGmBroadcastActive: async (active) => commandResult(await setGmBroadcastActive(active)),
+      onEndSplit: async () => commandResult(await endSplit())
+    }),
+    [
+      addRoom,
+      assignParticipantToRoom,
+      endSplit,
+      removeRoom,
+      renameRoom,
+      setGmBroadcastActive,
+      setGmFocusRoom,
+      startSplit
+    ]
+  );
+
+  const topBar = {
+    model: {
+      roomName,
+      displayName,
+      identity: connection.identity,
+      participantCount: collections.participantRoster.length,
+      activeWhisperCount: whisperSession.activeWhispers.length,
+      currentRoomName: splitSession.currentRoomName,
+      splitActive: splitSession.isActive,
+      spotlightIdentity: whisperSession.spotlightIdentity,
+      micEnabled: media.micEnabled,
+      cameraEnabled: media.cameraEnabled,
+      followSpotlight: whisperSession.followSpotlight,
+      sidebarOpen
+    } satisfies RoomTopBarViewModel,
+    actions: {
+      onToggleMic: media.toggleMic,
+      onToggleCamera: media.toggleCamera,
+      onFollowSpotlightChange: whisperSession.setFollowSpotlight,
+      onToggleSidebar: toggleSidebar,
+      onLeave: connection.disconnect
+    } satisfies RoomTopBarActions
+  };
+
+  const videoGrid = {
+    model: {
+      gridTiles: collections.gridTiles,
+      gridCount: Math.min(collections.gridTiles.length, 12),
+      spotlightIdentity: whisperSession.spotlightIdentity,
+      activeSpeakers: connection.activeSpeakers,
+      participantDisplayNames,
+      selectedParticipantIds: whisperSession.selectedParticipantIds,
+      mirrorSelfView: media.mirrorSelfView
+    } satisfies VideoGridViewModel,
+    actions: {
+      onToggleParticipantSelection: whisperSession.toggleParticipantSelection,
+      onToggleSpotlight: whisperSession.setSpotlight
+    } satisfies VideoGridActions
+  };
+
+  const whisperPanel = {
+    model: {
+      activeWhispers: whisperSession.activeWhispers,
+      selectedWhisperId: whisperSession.selectedWhisperId,
+      selectedWhisper: whisperSession.selectedWhisper,
+      selectedParticipants: whisperSession.selectedParticipants,
+      whisperNotice: whisperSession.whisperNotice,
+      isPttActive: media.isPttActive,
+      identity: connection.identity
+    } satisfies WhisperPanelViewModel,
+    actions: {
+      onCreateWhisper: whisperSession.createWhisper,
+      onSelectWhisper: whisperSession.setSelectedWhisperId,
+      onJoinWhisper: whisperSession.joinWhisper,
+      onAddSelectedParticipants: whisperSession.addSelectedParticipantsToWhisper,
+      onLeaveWhisper: whisperSession.leaveWhisper,
+      onCloseWhisper: whisperSession.closeWhisper
+    } satisfies WhisperPanelActions
+  };
+
+  const splitControl = splitSession.canManageSplitRooms
+    ? {
+        model: {
+          splitState: splitSession.splitState,
+          participants: collections.splitParticipants,
+          isPublishingCommand: splitSession.isPublishingCommand,
+          commandError: splitSession.commandError
+        } satisfies SplitControlPanelViewModel,
+        actions: splitControlActions
+      }
+    : undefined;
+
+  const devicePanel = {
+    model: {
+      audioDevices: media.audioDevices,
+      videoDevices: media.videoDevices,
+      selectedAudioDevice: media.selectedAudioDevice,
+      selectedVideoDevice: media.selectedVideoDevice,
+      mirrorSelfView: media.mirrorSelfView
+    } satisfies DevicePanelViewModel,
+    actions: {
+      onMirrorSelfViewChange: media.onMirrorSelfViewChange,
+      onSelectAudioDevice: media.onSelectAudioDevice,
+      onSelectVideoDevice: media.onSelectVideoDevice
+    } satisfies DevicePanelActions
+  };
+
+  return {
+    status: {
+      isConnecting: connection.isConnecting || media.isInitializing,
+      error: connection.error ?? media.error,
+      isConnected: Boolean(connection.room)
+    },
+    topBar,
+    videoGrid,
+    sidebar: {
+      open: sidebarOpen,
+      splitPanelVisible: splitSession.canManageSplitRooms || splitSession.isActive || Boolean(splitSession.notice),
+      splitControl,
+      splitStatus: {
+        isActive: splitSession.isActive,
+        currentRoomName: splitSession.currentRoomName,
+        participantCount: collections.participantRoster.length,
+        notice: splitSession.notice
+      },
+      whisperPanel,
+      participantRoster: {
+        items: collections.participantRoster,
+        title: splitSession.isActive ? "IN ROOM" : "AT TABLE"
+      },
+      devicePanel
+    },
+    audioLayer: {
+      tracks: collections.visibleAudioTracks,
+      mainVolume: whisperSession.mainVolume
+    }
+  };
+}

--- a/frontend/src/features/room-session/lib/session-selectors.test.ts
+++ b/frontend/src/features/room-session/lib/session-selectors.test.ts
@@ -3,6 +3,8 @@ import type { SplitState } from "@/lib/protocol";
 import { formatIdentityLabel, getWhisperLabel } from "@/features/room-session/lib/session-helpers";
 import {
   buildParticipantRoster,
+  buildRoomSessionCollections,
+  buildSplitParticipantOptions,
   filterAudioTracksForSplitView,
   filterParticipantIdentitiesForSplitView,
   orderGridTiles,
@@ -218,5 +220,95 @@ describe("room session selectors", () => {
         viewerIsGamemaster: false
       }).map((track) => track.identity)
     ).toEqual(["gm", "bob"]);
+  });
+
+  it("builds split participant options in GM, local, room, and label order", () => {
+    const splitState: SplitState = {
+      isActive: true,
+      rooms: [
+        { id: "main", name: "Main Table", kind: "main", updatedAt: 10 },
+        { id: "side-1", name: "Library", kind: "side", updatedAt: 10 }
+      ],
+      assignments: {
+        alice: "side-1",
+        bob: "main",
+        carol: "side-1"
+      },
+      gmIdentity: "gm",
+      gmBroadcastActive: false,
+      updatedAt: 10
+    };
+
+    const participants = buildSplitParticipantOptions({
+      participantIdentities: ["carol", "bob", "gm", "alice"],
+      participantDisplayNames: new Map([
+        ["alice", "Alice"],
+        ["bob", "Bob"],
+        ["carol", "Carol"],
+        ["gm", "Game Master"]
+      ]),
+      viewerIdentity: "alice",
+      splitState
+    });
+
+    expect(participants.map((participant) => participant.identity)).toEqual(["gm", "alice", "bob", "carol"]);
+    expect(participants.find((participant) => participant.identity === "alice")).toMatchObject({
+      isLocal: true,
+      roomId: "side-1"
+    });
+  });
+
+  it("builds the visible room-session collections at one tested boundary", () => {
+    const splitState: SplitState = {
+      isActive: true,
+      rooms: [
+        { id: "main", name: "Main Table", kind: "main", updatedAt: 10 },
+        { id: "side-1", name: "Library", kind: "side", updatedAt: 10 }
+      ],
+      assignments: {
+        alice: "main",
+        bob: "side-1"
+      },
+      gmIdentity: "gm",
+      gmFocusRoomId: "main",
+      gmBroadcastActive: false,
+      updatedAt: 10
+    };
+    const videoTiles: VideoTileModel[] = ["alice", "bob", "gm"].map((identity) => ({
+      key: `${identity}-track`,
+      identity,
+      trackSid: `${identity}-track`,
+      track: {} as VideoTileModel["track"],
+      isLocal: identity === "alice"
+    }));
+    const audioTracks: AudioTrackModel[] = ["bob", "gm"].map((identity) => ({
+      key: `${identity}-audio`,
+      identity,
+      track: {} as AudioTrackModel["track"],
+      isMain: true
+    }));
+
+    const collections = buildRoomSessionCollections({
+      participantIdentities: ["alice", "bob", "gm"],
+      participantDisplayNames: new Map([
+        ["alice", "Alice"],
+        ["bob", "Bob"],
+        ["gm", "Game Master"]
+      ]),
+      viewerIdentity: "alice",
+      viewerIsGamemaster: false,
+      activeSpeakers: new Set(["gm"]),
+      videoTiles,
+      audioTracks,
+      activeWhispers: [],
+      spotlightIdentity: "gm",
+      splitState
+    });
+
+    expect(collections.gridTiles.map((tile) => tile.identity)).toEqual(["gm", "alice"]);
+    expect(collections.participantRoster.map((participant) => participant.identity)).toEqual(["gm", "alice"]);
+    expect(collections.participantRoster[0]).toMatchObject({ isSpeaking: true, isSpotlight: true });
+    expect(collections.visibleAudioTracks.map((track) => track.identity)).toEqual(["gm"]);
+    expect(collections.splitParticipants.map((participant) => participant.identity)).toEqual(["gm", "alice", "bob"]);
   });
 });

--- a/frontend/src/features/room-session/lib/session-selectors.ts
+++ b/frontend/src/features/room-session/lib/session-selectors.ts
@@ -1,7 +1,12 @@
 import { Track } from "livekit-client";
 import type { RemoteTrack, Room } from "livekit-client";
 import type { SplitState, Whisper } from "@/lib/protocol";
-import type { AudioTrackModel, ParticipantRosterItem, VideoTileModel } from "@/features/room-session/types";
+import type {
+  AudioTrackModel,
+  ParticipantRosterItem,
+  SplitParticipantOption,
+  VideoTileModel
+} from "@/features/room-session/types";
 import { formatIdentityLabel, getWhisperLabel } from "@/features/room-session/lib/session-helpers";
 
 export const MAIN_SPLIT_ROOM_ID = "main";
@@ -128,12 +133,12 @@ function addDisplayName(displayNames: Map<string, string>, identity: string | un
 }
 
 type BuildParticipantRosterInput = {
-  participantIdentities: string[];
+  participantIdentities: ReadonlyArray<string>;
   participantDisplayNames?: ReadonlyMap<string, string>;
   identity: string;
-  activeSpeakers: Set<string>;
-  videoTiles: VideoTileModel[];
-  activeWhispers: Whisper[];
+  activeSpeakers: ReadonlySet<string>;
+  videoTiles: ReadonlyArray<VideoTileModel>;
+  activeWhispers: ReadonlyArray<Whisper>;
   spotlightIdentity?: string;
 };
 
@@ -176,7 +181,10 @@ export function buildParticipantRoster({
     });
 }
 
-export function orderGridTiles(videoTiles: VideoTileModel[], spotlightIdentity?: string): VideoTileModel[] {
+export function orderGridTiles(
+  videoTiles: ReadonlyArray<VideoTileModel>,
+  spotlightIdentity?: string
+): VideoTileModel[] {
   const ordered = [...videoTiles];
   if (!spotlightIdentity) {
     return ordered;
@@ -212,11 +220,11 @@ type SplitViewInput = {
 };
 
 export function filterParticipantIdentitiesForSplitView(
-  participantIdentities: string[],
+  participantIdentities: ReadonlyArray<string>,
   splitView: SplitViewInput
 ): string[] {
   if (!splitView.splitState.isActive || splitView.viewerIsGamemaster || !splitView.viewerIdentity) {
-    return participantIdentities;
+    return [...participantIdentities];
   }
 
   const viewerRoomId = resolveParticipantRoomId(splitView.splitState, splitView.viewerIdentity);
@@ -234,7 +242,7 @@ export function filterParticipantIdentitiesForSplitView(
 }
 
 export function filterVideoTilesForSplitView(
-  videoTiles: VideoTileModel[],
+  videoTiles: ReadonlyArray<VideoTileModel>,
   splitView: SplitViewInput
 ): VideoTileModel[] {
   const visibleParticipants = new Set(filterParticipantIdentitiesForSplitView(videoTiles.map((tile) => tile.identity), splitView));
@@ -242,11 +250,11 @@ export function filterVideoTilesForSplitView(
 }
 
 export function filterAudioTracksForSplitView(
-  audioTracks: AudioTrackModel[],
+  audioTracks: ReadonlyArray<AudioTrackModel>,
   splitView: SplitViewInput
 ): AudioTrackModel[] {
   if (!splitView.splitState.isActive || splitView.viewerIsGamemaster || !splitView.viewerIdentity) {
-    return audioTracks;
+    return [...audioTracks];
   }
 
   const viewerRoomId = resolveParticipantRoomId(splitView.splitState, splitView.viewerIdentity);
@@ -264,4 +272,101 @@ export function filterAudioTracksForSplitView(
 
     return resolveParticipantRoomId(splitView.splitState, track.identity) === viewerRoomId;
   });
+}
+
+type BuildSplitParticipantOptionsInput = {
+  participantIdentities: ReadonlyArray<string>;
+  participantDisplayNames?: ReadonlyMap<string, string>;
+  viewerIdentity: string;
+  splitState: SplitState;
+};
+
+export function buildSplitParticipantOptions({
+  participantIdentities,
+  participantDisplayNames,
+  viewerIdentity,
+  splitState
+}: BuildSplitParticipantOptionsInput): SplitParticipantOption[] {
+  return participantIdentities
+    .map((participantIdentity) => ({
+      identity: participantIdentity,
+      label: resolveParticipantLabel(participantIdentity, participantDisplayNames),
+      isLocal: participantIdentity === viewerIdentity,
+      roomId: resolveParticipantRoomId(splitState, participantIdentity)
+    }))
+    .sort((left, right) => {
+      if (left.identity === splitState.gmIdentity && right.identity !== splitState.gmIdentity) {
+        return -1;
+      }
+      if (right.identity === splitState.gmIdentity && left.identity !== splitState.gmIdentity) {
+        return 1;
+      }
+      if (left.isLocal && !right.isLocal) {
+        return -1;
+      }
+      if (right.isLocal && !left.isLocal) {
+        return 1;
+      }
+      if (left.roomId !== right.roomId) {
+        return left.roomId.localeCompare(right.roomId);
+      }
+      return left.label.localeCompare(right.label);
+    });
+}
+
+type BuildRoomSessionCollectionsInput = {
+  participantIdentities: ReadonlyArray<string>;
+  participantDisplayNames: ReadonlyMap<string, string>;
+  viewerIdentity: string;
+  viewerIsGamemaster: boolean;
+  activeSpeakers: ReadonlySet<string>;
+  videoTiles: ReadonlyArray<VideoTileModel>;
+  audioTracks: ReadonlyArray<AudioTrackModel>;
+  activeWhispers: ReadonlyArray<Whisper>;
+  spotlightIdentity?: string;
+  splitState: SplitState;
+};
+
+export type RoomSessionCollections = {
+  gridTiles: VideoTileModel[];
+  participantRoster: ParticipantRosterItem[];
+  splitParticipants: SplitParticipantOption[];
+  visibleAudioTracks: AudioTrackModel[];
+};
+
+export function buildRoomSessionCollections({
+  participantIdentities,
+  participantDisplayNames,
+  viewerIdentity,
+  viewerIsGamemaster,
+  activeSpeakers,
+  videoTiles,
+  audioTracks,
+  activeWhispers,
+  spotlightIdentity,
+  splitState
+}: BuildRoomSessionCollectionsInput): RoomSessionCollections {
+  const splitView = { splitState, viewerIdentity, viewerIsGamemaster };
+  const visibleParticipantIdentities = filterParticipantIdentitiesForSplitView(participantIdentities, splitView);
+  const visibleVideoTiles = filterVideoTilesForSplitView(videoTiles, splitView);
+
+  return {
+    gridTiles: orderGridTiles(visibleVideoTiles, spotlightIdentity),
+    participantRoster: buildParticipantRoster({
+      participantIdentities: visibleParticipantIdentities,
+      participantDisplayNames,
+      identity: viewerIdentity,
+      activeSpeakers,
+      videoTiles: visibleVideoTiles,
+      activeWhispers,
+      spotlightIdentity
+    }),
+    splitParticipants: buildSplitParticipantOptions({
+      participantIdentities,
+      participantDisplayNames,
+      viewerIdentity,
+      splitState
+    }),
+    visibleAudioTracks: filterAudioTracksForSplitView(audioTracks, splitView)
+  };
 }

--- a/frontend/src/features/room-session/types.ts
+++ b/frontend/src/features/room-session/types.ts
@@ -1,5 +1,5 @@
 import type { Track } from "livekit-client";
-import type { Whisper } from "@/lib/protocol";
+import type { SplitState, Whisper } from "@/lib/protocol";
 
 export type GameRole = "gamemaster" | "player";
 
@@ -28,11 +28,22 @@ export type ParticipantRosterItem = {
   whisperLabel?: string;
 };
 
-export type RoomSessionControls = {
+export type RoomTopBarViewModel = {
+  roomName: string;
+  displayName: string;
+  identity: string;
+  participantCount: number;
+  activeWhisperCount: number;
+  currentRoomName?: string;
+  splitActive: boolean;
+  spotlightIdentity?: string;
   micEnabled: boolean;
   cameraEnabled: boolean;
   followSpotlight: boolean;
   sidebarOpen: boolean;
+};
+
+export type RoomTopBarActions = {
   onToggleMic: () => Promise<void>;
   onToggleCamera: () => Promise<void>;
   onFollowSpotlightChange: (follow: boolean) => void;
@@ -40,14 +51,65 @@ export type RoomSessionControls = {
   onLeave: () => void;
 };
 
-export type WhisperPanelState = {
-  activeWhispers: Whisper[];
+export type WhisperPanelViewModel = {
+  activeWhispers: ReadonlyArray<Whisper>;
   selectedWhisperId?: string;
   selectedWhisper?: Whisper;
-  selectedParticipants: string[];
+  selectedParticipants: ReadonlyArray<string>;
   whisperNotice: string | null;
   isPttActive: boolean;
   identity: string;
+};
+
+export type WhisperPanelActions = {
+  onCreateWhisper: () => Promise<void>;
+  onSelectWhisper: (whisperId?: string) => void;
+  onJoinWhisper: (whisper: Whisper) => Promise<void>;
+  onAddSelectedParticipants: (whisper: Whisper) => Promise<void>;
+  onLeaveWhisper: (whisper: Whisper) => Promise<void>;
+  onCloseWhisper: (whisper: Whisper) => Promise<void>;
+};
+
+export type SplitParticipantOption = {
+  identity: string;
+  label: string;
+  isLocal: boolean;
+  roomId: string;
+};
+
+export type SplitControlPanelViewModel = {
+  splitState: SplitState;
+  participants: ReadonlyArray<SplitParticipantOption>;
+  isPublishingCommand: boolean;
+  commandError: string | null;
+};
+
+export type CommandResult = { ok: true } | { ok: false };
+
+export type SplitControlPanelActions = {
+  onStartSplit: () => Promise<CommandResult>;
+  onAddRoom: () => Promise<CommandResult>;
+  onRemoveRoom: (roomId: string) => Promise<CommandResult>;
+  onRenameRoom: (roomId: string, roomName: string) => Promise<CommandResult>;
+  onAssignParticipantToRoom: (participantIdentity: string, roomId: string) => Promise<CommandResult>;
+  onSetGmFocusRoom: (roomId: string | null) => Promise<CommandResult>;
+  onSetGmBroadcastActive: (active: boolean) => Promise<CommandResult>;
+  onEndSplit: () => Promise<CommandResult>;
+};
+
+export type VideoGridViewModel = {
+  gridTiles: ReadonlyArray<VideoTileModel>;
+  gridCount: number;
+  spotlightIdentity?: string;
+  activeSpeakers: ReadonlySet<string>;
+  participantDisplayNames: ReadonlyMap<string, string>;
+  selectedParticipantIds: ReadonlySet<string>;
+  mirrorSelfView: boolean;
+};
+
+export type VideoGridActions = {
+  onToggleParticipantSelection: (participantIdentity: string) => void;
+  onToggleSpotlight: (participantIdentity: string | null) => Promise<void>;
 };
 
 export type DevicePanelViewModel = {


### PR DESCRIPTION
## Summary
- add cohesive model/action contracts for the room top bar, whisper, split controls, and video grid
- move room-session hooks and derived UI collections behind a focused view-model boundary
- extract and test aggregate room/split participant selectors while preserving rendered behavior

## Validation
- `npm exec --yes pnpm@10.30.3 -- --filter frontend lint`
- `npm exec --yes pnpm@10.30.3 -- --filter frontend typecheck`
- `npm exec --yes pnpm@10.30.3 -- --filter frontend test` (77 passed)
- `npm exec --yes pnpm@10.30.3 -- --filter frontend build`
- Playwright: 7 passed, including two- and three-client realtime flows

Closes #133
Closes #136