### PR TITLE
refactor(room-session): centralize data channel protocol

### DIFF
--- a/docs/contracts/datachannel-protocol.md
+++ b/docs/contracts/datachannel-protocol.md
@@ -13,6 +13,20 @@ All messages are JSON objects:
 }
 ```
 
+## Transport lifecycle
+
+The room session owns one shared DataChannel protocol boundary for all v1 event types. It:
+
+- encodes outgoing envelopes and publishes them reliably;
+- decodes and validates incoming envelopes before routing them;
+- installs one `RoomEvent.DataReceived` listener per connected room;
+- fans valid envelopes out by their discriminated `type` to feature handlers; and
+- reports publish outcomes as `ok`, `room-unavailable`, or `publish-failed`.
+
+Whisper and split-room handlers retain their domain responsibilities. Whisper handlers own whisper snapshots and reducer updates. Split-room handlers verify the trusted LiveKit sender identity and gamemaster authority before applying state.
+
+When a participant joins, the whisper and split features each publish their typed state request. Existing eligible participants answer with feature-specific snapshots, so a late joiner hydrates through the same shared listener and routing boundary.
+
 ## Whisper payload
 
 ```json

--- a/docs/plans/2026-07-09_shared-room-protocol.md
+++ b/docs/plans/2026-07-09_shared-room-protocol.md
@@ -1,0 +1,7 @@
+# Shared room protocol implementation plan
+
+1. Add a typed room protocol boundary that owns reliable publishing, envelope encoding/decoding, one LiveKit data listener, and event-type routing.
+2. Instantiate the boundary once in `RoomSessionController` and migrate whisper/split feature hooks to register typed handlers while retaining their state-request, snapshot, authority, and reducer behavior.
+3. Add unit coverage for whisper/split routing, malformed payload rejection, unsubscribe behavior, and publish results; document the transport lifecycle.
+4. Run frontend lint, typecheck, unit tests, build, and multi-client Playwright late-join snapshot checks.
+5. Review the diff, commit, push, open a closing PR, and monitor required checks.

--- a/frontend/e2e/whisper.spec.ts
+++ b/frontend/e2e/whisper.spec.ts
@@ -247,4 +247,27 @@ test.describe("whisper multi-client flows", () => {
       await carol.context.close();
     }
   });
+
+  test("hydrates a late joiner from the whisper state snapshot", async ({ browser }) => {
+    const alice = await openParticipant(browser, TEST_ROOM, "Alice");
+    const bob = await openParticipant(browser, TEST_ROOM, "Bob");
+    let carol: ParticipantClient | undefined;
+
+    try {
+      await Promise.all([ensureCameraOn(alice.page), ensureCameraOn(bob.page)]);
+      await waitForRemoteTile(alice.page, bob.identity);
+      await clickVideoSelect(alice.page, bob.identity);
+      await alice.page.getByRole("button", { name: "New Whisper" }).click();
+      await expect(await whisperCardForMember(bob.page, alice.identity)).toBeVisible();
+
+      carol = await openParticipant(browser, TEST_ROOM, "Carol");
+      const lateJoinerCard = await whisperCardForMember(carol.page, alice.identity);
+      await expect(lateJoinerCard).toContainText(bob.identity);
+      await expect(lateJoinerCard.getByRole("button", { name: "Join" })).toBeVisible();
+    } finally {
+      await carol?.context.close();
+      await alice.context.close();
+      await bob.context.close();
+    }
+  });
 });

--- a/frontend/src/features/room-session/hooks/useRoomProtocol.ts
+++ b/frontend/src/features/room-session/hooks/useRoomProtocol.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { RoomEvent } from "livekit-client";
+import type { Participant, Room } from "livekit-client";
+import {
+  createRoomProtocolRouter,
+  publishRoomProtocolEnvelope
+} from "@/features/room-session/lib/room-protocol";
+import type {
+  RoomProtocol,
+  RoomProtocolRouter
+} from "@/features/room-session/lib/room-protocol";
+
+export function useRoomProtocol(room: Room | null): RoomProtocol {
+  const routerRef = useRef<RoomProtocolRouter | null>(null);
+  if (!routerRef.current) {
+    routerRef.current = createRoomProtocolRouter();
+  }
+  const router = routerRef.current;
+
+  useEffect(() => {
+    if (!room) {
+      return;
+    }
+
+    const onData = (payload: Uint8Array, participant?: Participant) => {
+      router.route(payload, participant);
+    };
+
+    room.on(RoomEvent.DataReceived, onData);
+    return () => {
+      room.off(RoomEvent.DataReceived, onData);
+    };
+  }, [room, router]);
+
+  const publish: RoomProtocol["publish"] = useCallback(
+    (envelope) => publishRoomProtocolEnvelope(room, envelope),
+    [room]
+  );
+
+  return useMemo(
+    () => ({
+      publish,
+      subscribe: router.subscribe
+    }),
+    [publish, router]
+  );
+}

--- a/frontend/src/features/room-session/hooks/useRoomSessionViewModel.ts
+++ b/frontend/src/features/room-session/hooks/useRoomSessionViewModel.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useRoomConnection } from "@/features/room-session/hooks/useRoomConnection";
 import { useRoomMedia } from "@/features/room-session/hooks/useRoomMedia";
 import { useRoomParticipants } from "@/features/room-session/hooks/useRoomParticipants";
+import { useRoomProtocol } from "@/features/room-session/hooks/useRoomProtocol";
 import { useSplitRoomSession } from "@/features/room-session/hooks/useSplitRoomSession";
 import { useWhisperSession } from "@/features/room-session/hooks/useWhisperSession";
 import {
@@ -37,6 +38,7 @@ export function useRoomSessionViewModel({ roomName, displayName }: UseRoomSessio
 
   const connection = useRoomConnection({ roomName, displayName });
   const media = useRoomMedia({ room: connection.room });
+  const protocol = useRoomProtocol(connection.room);
   const { participantDisplayNames, participantIdentities } = useRoomParticipants({
     room: connection.room,
     identity: connection.identity,
@@ -45,12 +47,14 @@ export function useRoomSessionViewModel({ roomName, displayName }: UseRoomSessio
   });
   const splitSession = useSplitRoomSession({
     room: connection.room,
+    protocol,
     identity: connection.identity,
     gameRole: connection.gameRole,
     participantIdentities
   });
   const whisperSession = useWhisperSession({
     room: connection.room,
+    protocol,
     identity: connection.identity,
     renderVersion: connection.renderVersion,
     splitState: splitSession.splitState,

--- a/frontend/src/features/room-session/hooks/useSplitRoomSession.ts
+++ b/frontend/src/features/room-session/hooks/useSplitRoomSession.ts
@@ -2,9 +2,12 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { AnyProtocolEnvelope, SplitState } from "@/lib/protocol";
-import { RoomEvent } from "livekit-client";
-import type { Participant, Room } from "livekit-client";
-import { createEnvelope, parseProtocolEnvelope } from "@/lib/protocol";
+import type { Room } from "livekit-client";
+import { createEnvelope } from "@/lib/protocol";
+import type {
+  RoomProtocol,
+  RoomProtocolMessageContext
+} from "@/features/room-session/lib/room-protocol";
 import { MAIN_SPLIT_ROOM_ID, MAIN_SPLIT_ROOM_NAME, resolveParticipantRoomId } from "@/features/room-session/lib/session-selectors";
 import { createNextSideRoom, createSplitStartState } from "@/features/room-session/lib/split-room-commands";
 import {
@@ -19,12 +22,13 @@ import type { GameRole } from "@/features/room-session/types";
 
 type UseSplitRoomSessionInput = {
   room: Room | null;
+  protocol: RoomProtocol;
   identity: string;
   gameRole?: GameRole;
   participantIdentities: string[];
 };
 
-export function useSplitRoomSession({ room, identity, gameRole, participantIdentities }: UseSplitRoomSessionInput) {
+export function useSplitRoomSession({ room, protocol, identity, gameRole, participantIdentities }: UseSplitRoomSessionInput) {
   const isActive = useSplitRoomStore((state) => state.isActive);
   const rooms = useSplitRoomStore((state) => state.rooms);
   const roomOrder = useSplitRoomStore((state) => state.roomOrder);
@@ -43,24 +47,18 @@ export function useSplitRoomSession({ room, identity, gameRole, participantIdent
 
   const publishSplitEnvelope = useCallback(
     async (envelope: AnyProtocolEnvelope, applyLocally = true) => {
-      if (!room) {
+      const result = await protocol.publish(envelope);
+      if (!result.ok) {
         return false;
       }
 
-      try {
-        const payload = new TextEncoder().encode(JSON.stringify(envelope));
-        await room.localParticipant.publishData(payload, { reliable: true });
-
-        if (applyLocally) {
-          applyEnvelope(envelope);
-        }
-
-        return true;
-      } catch {
-        return false;
+      if (applyLocally) {
+        applyEnvelope(envelope);
       }
+
+      return true;
     },
-    [applyEnvelope, room]
+    [applyEnvelope, protocol]
   );
 
   const publishManagedEnvelope = useCallback(
@@ -92,39 +90,41 @@ export function useSplitRoomSession({ room, identity, gameRole, participantIdent
       return;
     }
 
-    const onData = (payload: Uint8Array, participant?: Participant) => {
-      const raw = new TextDecoder().decode(payload);
-      const envelope = parseProtocolEnvelope(raw);
-      if (!envelope) {
-        return;
-      }
-
-      const senderIdentity = participant?.identity ?? envelope.actor;
+    const onStateRequest = (
+      envelope: Extract<AnyProtocolEnvelope, { type: "SPLIT_STATE_REQUEST" }>,
+      { senderIdentity }: RoomProtocolMessageContext
+    ) => {
       if (envelope.actor !== senderIdentity) {
         return;
       }
 
-      if (envelope.type === "SPLIT_STATE_REQUEST") {
-        const currentStore = useSplitRoomStore.getState();
-        const splitState = selectSplitState(currentStore);
+      const currentStore = useSplitRoomStore.getState();
+      const currentSplitState = selectSplitState(currentStore);
 
-        if (!splitState.isActive) {
-          return;
-        }
+      if (!currentSplitState.isActive) {
+        return;
+      }
 
-        const mayReplyToStateRequest = canManageSplitAuthority({
-          splitState,
-          identity,
-          gameRole
-        });
-        if (!mayReplyToStateRequest) {
-          return;
-        }
+      const mayReplyToStateRequest = canManageSplitAuthority({
+        splitState: currentSplitState,
+        identity,
+        gameRole
+      });
+      if (!mayReplyToStateRequest) {
+        return;
+      }
 
-        const snapshot = createEnvelope("SPLIT_STATE_SNAPSHOT", identity, {
-          splitState
-        });
-        void publishSplitEnvelope(snapshot, false);
+      const snapshot = createEnvelope("SPLIT_STATE_SNAPSHOT", identity, {
+        splitState: currentSplitState
+      });
+      void publishSplitEnvelope(snapshot, false);
+    };
+
+    const onSplitEnvelope = (
+      envelope: AnyProtocolEnvelope,
+      { participant, senderIdentity }: RoomProtocolMessageContext
+    ) => {
+      if (envelope.actor !== senderIdentity) {
         return;
       }
 
@@ -148,15 +148,25 @@ export function useSplitRoomSession({ room, identity, gameRole, participantIdent
       applyEnvelope(envelope);
     };
 
-    room.on(RoomEvent.DataReceived, onData);
+    const unsubscribers = [
+      protocol.subscribe("SPLIT_STATE_REQUEST", onStateRequest),
+      protocol.subscribe("SPLIT_STATE_SNAPSHOT", onSplitEnvelope),
+      protocol.subscribe("SPLIT_START", onSplitEnvelope),
+      protocol.subscribe("SPLIT_END", onSplitEnvelope),
+      protocol.subscribe("SPLIT_ROOM_UPSERT", onSplitEnvelope),
+      protocol.subscribe("SPLIT_ROOM_REMOVE", onSplitEnvelope),
+      protocol.subscribe("SPLIT_ASSIGNMENT_SET", onSplitEnvelope),
+      protocol.subscribe("SPLIT_GM_FOCUS_UPDATE", onSplitEnvelope),
+      protocol.subscribe("SPLIT_GM_BROADCAST_UPDATE", onSplitEnvelope)
+    ];
 
     const stateRequest = createEnvelope("SPLIT_STATE_REQUEST", identity, {});
     void publishSplitEnvelope(stateRequest, false);
 
     return () => {
-      room.off(RoomEvent.DataReceived, onData);
+      unsubscribers.forEach((unsubscribe) => unsubscribe());
     };
-  }, [applyEnvelope, gameRole, identity, publishSplitEnvelope, room, reset]);
+  }, [applyEnvelope, gameRole, identity, protocol, publishSplitEnvelope, room, reset]);
 
   const splitState = useMemo<SplitState>(
     () => ({

--- a/frontend/src/features/room-session/hooks/useWhisperSession.ts
+++ b/frontend/src/features/room-session/hooks/useWhisperSession.ts
@@ -1,13 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { RoomEvent, Track } from "livekit-client";
+import { Track } from "livekit-client";
 import type { Room } from "livekit-client";
+import type { RoomProtocol } from "@/features/room-session/lib/room-protocol";
 import { createUuid } from "@/lib/client-id";
-import {
-  createEnvelope,
-  parseProtocolEnvelope
-} from "@/lib/protocol";
+import { createEnvelope } from "@/lib/protocol";
 import type { AnyProtocolEnvelope, SpotlightPayload, SplitState, Whisper, WhisperClosePayload } from "@/lib/protocol";
 import { canUseWhisperMembersInSplit, filterWhispersForSplitView } from "@/features/room-session/lib/split-room-rules";
 import { useWhisperPtt } from "@/hooks/useWhisperPtt";
@@ -16,6 +14,7 @@ import { useWhisperStore } from "@/store/whisperStore";
 
 type UseWhisperSessionInput = {
   room: Room | null;
+  protocol: RoomProtocol;
   identity: string;
   renderVersion: number;
   splitState: SplitState;
@@ -27,6 +26,7 @@ type UseWhisperSessionInput = {
 
 export function useWhisperSession({
   room,
+  protocol,
   identity,
   renderVersion,
   splitState,
@@ -79,24 +79,18 @@ export function useWhisperSession({
 
   const publishEnvelope = useCallback(
     async (envelope: AnyProtocolEnvelope, applyLocally = true) => {
-      if (!room) {
+      const result = await protocol.publish(envelope);
+      if (!result.ok) {
         return false;
       }
 
-      try {
-        const payload = new TextEncoder().encode(JSON.stringify(envelope));
-        await room.localParticipant.publishData(payload, { reliable: true });
-
-        if (applyLocally) {
-          applyEnvelope(envelope);
-        }
-
-        return true;
-      } catch {
-        return false;
+      if (applyLocally) {
+        applyEnvelope(envelope);
       }
+
+      return true;
     },
-    [applyEnvelope, room]
+    [applyEnvelope, protocol]
   );
 
   useEffect(() => {
@@ -104,34 +98,30 @@ export function useWhisperSession({
       return;
     }
 
-    const onData = (payload: Uint8Array) => {
-      const raw = new TextDecoder().decode(payload);
-      const envelope = parseProtocolEnvelope(raw);
-      if (!envelope) {
-        return;
-      }
-
-      if (envelope.type === "STATE_REQUEST") {
-        const snapshot = createEnvelope("STATE_SNAPSHOT", identity, {
-          whispers: Object.values(useWhisperStore.getState().whispers),
-          spotlightIdentity: useWhisperStore.getState().spotlightIdentity ?? null
-        });
-        void publishEnvelope(snapshot, false);
-        return;
-      }
-
-      applyEnvelope(envelope);
+    const onStateRequest = () => {
+      const snapshot = createEnvelope("STATE_SNAPSHOT", identity, {
+        whispers: Object.values(useWhisperStore.getState().whispers),
+        spotlightIdentity: useWhisperStore.getState().spotlightIdentity ?? null
+      });
+      void publishEnvelope(snapshot, false);
     };
 
-    room.on(RoomEvent.DataReceived, onData);
+    const unsubscribers = [
+      protocol.subscribe("STATE_REQUEST", onStateRequest),
+      protocol.subscribe("STATE_SNAPSHOT", applyEnvelope),
+      protocol.subscribe("WHISPER_CREATE", applyEnvelope),
+      protocol.subscribe("WHISPER_UPDATE", applyEnvelope),
+      protocol.subscribe("WHISPER_CLOSE", applyEnvelope),
+      protocol.subscribe("SPOTLIGHT_UPDATE", applyEnvelope)
+    ];
 
     const stateRequest = createEnvelope("STATE_REQUEST", identity, {});
     void publishEnvelope(stateRequest, false);
 
     return () => {
-      room.off(RoomEvent.DataReceived, onData);
+      unsubscribers.forEach((unsubscribe) => unsubscribe());
     };
-  }, [applyEnvelope, identity, publishEnvelope, room]);
+  }, [applyEnvelope, identity, protocol, publishEnvelope, room]);
 
   useEffect(() => {
     if (!room) {

--- a/frontend/src/features/room-session/lib/room-protocol.test.ts
+++ b/frontend/src/features/room-session/lib/room-protocol.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Participant, Room } from "livekit-client";
+import {
+  createRoomProtocolRouter,
+  decodeRoomProtocolEnvelope,
+  encodeRoomProtocolEnvelope,
+  publishRoomProtocolEnvelope
+} from "@/features/room-session/lib/room-protocol";
+import { createEnvelope } from "@/lib/protocol";
+
+describe("room protocol router", () => {
+  it("routes whisper and split envelopes only to their typed subscribers", () => {
+    const router = createRoomProtocolRouter();
+    const whisperHandler = vi.fn();
+    const whisperObserver = vi.fn();
+    const splitHandler = vi.fn();
+    const unsubscribeWhisper = router.subscribe("WHISPER_CREATE", whisperHandler);
+    router.subscribe("WHISPER_CREATE", whisperObserver);
+    router.subscribe("SPLIT_STATE_SNAPSHOT", splitHandler);
+
+    const whisperEnvelope = createEnvelope("WHISPER_CREATE", "alice", {
+      id: "whisper-1",
+      members: ["alice", "bob"],
+      createdBy: "alice",
+      createdAt: 10,
+      updatedAt: 10
+    });
+    const splitEnvelope = createEnvelope("SPLIT_STATE_SNAPSHOT", "gm", {
+      splitState: {
+        isActive: true,
+        rooms: [{ id: "main", name: "Main Table", kind: "main", updatedAt: 20 }],
+        assignments: { alice: "main" },
+        gmIdentity: "gm",
+        gmBroadcastActive: false,
+        updatedAt: 20
+      }
+    });
+    const gmParticipant = {
+      identity: "gm",
+      attributes: { game_role: "gamemaster" }
+    } as unknown as Participant;
+
+    expect(router.route(encodeRoomProtocolEnvelope(whisperEnvelope))).toBe(true);
+    expect(whisperHandler).toHaveBeenCalledWith(
+      whisperEnvelope,
+      expect.objectContaining({ senderIdentity: "alice" })
+    );
+    expect(whisperObserver).toHaveBeenCalledTimes(1);
+    expect(splitHandler).not.toHaveBeenCalled();
+
+    expect(router.route(encodeRoomProtocolEnvelope(splitEnvelope), gmParticipant)).toBe(true);
+    expect(splitHandler).toHaveBeenCalledWith(splitEnvelope, {
+      participant: gmParticipant,
+      senderIdentity: "gm"
+    });
+    expect(whisperHandler).toHaveBeenCalledTimes(1);
+
+    unsubscribeWhisper();
+    router.route(encodeRoomProtocolEnvelope(whisperEnvelope));
+    expect(whisperHandler).toHaveBeenCalledTimes(1);
+    expect(whisperObserver).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects malformed data before routing", () => {
+    const router = createRoomProtocolRouter();
+    const handler = vi.fn();
+    router.subscribe("WHISPER_UPDATE", handler);
+
+    expect(router.route(new TextEncoder().encode('{"type":"WHISPER_UPDATE"}'))).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe("room protocol publishing", () => {
+  it("encodes and reliably publishes an envelope", async () => {
+    const publishData = vi.fn().mockResolvedValue(undefined);
+    const room = { localParticipant: { publishData } } as unknown as Room;
+    const envelope = createEnvelope("SPOTLIGHT_UPDATE", "alice", {
+      identity: "bob",
+      updatedAt: 30
+    });
+
+    await expect(publishRoomProtocolEnvelope(room, envelope)).resolves.toEqual({ ok: true });
+    expect(publishData).toHaveBeenCalledTimes(1);
+    const [payload, options] = publishData.mock.calls[0] as [Uint8Array, { reliable: boolean }];
+    expect(options).toEqual({ reliable: true });
+    expect(decodeRoomProtocolEnvelope(payload)).toEqual(envelope);
+  });
+
+  it("returns typed failures when the room is unavailable or publish rejects", async () => {
+    const envelope = createEnvelope("STATE_REQUEST", "alice", {});
+    await expect(publishRoomProtocolEnvelope(null, envelope)).resolves.toEqual({
+      ok: false,
+      reason: "room-unavailable"
+    });
+
+    const room = {
+      localParticipant: { publishData: vi.fn().mockRejectedValue(new Error("offline")) }
+    } as unknown as Room;
+    await expect(publishRoomProtocolEnvelope(room, envelope)).resolves.toEqual({
+      ok: false,
+      reason: "publish-failed"
+    });
+  });
+});

--- a/frontend/src/features/room-session/lib/room-protocol.ts
+++ b/frontend/src/features/room-session/lib/room-protocol.ts
@@ -1,0 +1,113 @@
+import type { Participant, Room } from "livekit-client";
+import type {
+  AnyProtocolEnvelope,
+  ProtocolEventType
+} from "@/lib/protocol";
+import { parseProtocolEnvelope } from "@/lib/protocol";
+
+export type RoomProtocolMessageContext = Readonly<{
+  participant?: Participant;
+  senderIdentity: string;
+}>;
+
+export type RoomProtocolMessageHandler<T extends ProtocolEventType> = (
+  envelope: Extract<AnyProtocolEnvelope, { type: T }>,
+  context: RoomProtocolMessageContext
+) => void;
+
+export type RoomProtocolPublishResult =
+  | Readonly<{ ok: true }>
+  | Readonly<{ ok: false; reason: "room-unavailable" | "publish-failed" }>;
+
+export type RoomProtocol = Readonly<{
+  publish: <T extends ProtocolEventType>(
+    envelope: Extract<AnyProtocolEnvelope, { type: T }>
+  ) => Promise<RoomProtocolPublishResult>;
+  subscribe: <T extends ProtocolEventType>(
+    type: T,
+    handler: RoomProtocolMessageHandler<T>
+  ) => () => void;
+}>;
+
+type AnyRoomProtocolMessageHandler = (
+  envelope: AnyProtocolEnvelope,
+  context: RoomProtocolMessageContext
+) => void;
+
+type ProtocolSubscription = Readonly<{
+  type: ProtocolEventType;
+  handler: AnyRoomProtocolMessageHandler;
+}>;
+
+export type RoomProtocolRouter = Readonly<{
+  route: (payload: Uint8Array, participant?: Participant) => boolean;
+  subscribe: RoomProtocol["subscribe"];
+}>;
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export function createRoomProtocolRouter(): RoomProtocolRouter {
+  const subscriptions = new Set<ProtocolSubscription>();
+
+  const subscribe: RoomProtocol["subscribe"] = (type, handler) => {
+    const subscription: ProtocolSubscription = {
+      type,
+      handler: handler as AnyRoomProtocolMessageHandler
+    };
+    subscriptions.add(subscription);
+
+    return () => {
+      subscriptions.delete(subscription);
+    };
+  };
+
+  return {
+    route: (payload, participant) => {
+      const envelope = decodeRoomProtocolEnvelope(payload);
+      if (!envelope) {
+        return false;
+      }
+
+      const context: RoomProtocolMessageContext = {
+        participant,
+        senderIdentity: participant?.identity ?? envelope.actor
+      };
+
+      for (const subscription of subscriptions) {
+        if (subscription.type === envelope.type) {
+          subscription.handler(envelope, context);
+        }
+      }
+
+      return true;
+    },
+    subscribe
+  };
+}
+
+export async function publishRoomProtocolEnvelope<T extends ProtocolEventType>(
+  room: Room | null,
+  envelope: Extract<AnyProtocolEnvelope, { type: T }>
+): Promise<RoomProtocolPublishResult> {
+  if (!room) {
+    return { ok: false, reason: "room-unavailable" };
+  }
+
+  try {
+    await room.localParticipant.publishData(encodeRoomProtocolEnvelope(envelope), {
+      reliable: true
+    });
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "publish-failed" };
+  }
+}
+
+export function encodeRoomProtocolEnvelope(envelope: AnyProtocolEnvelope): Uint8Array {
+  return textEncoder.encode(JSON.stringify(envelope));
+}
+
+export function decodeRoomProtocolEnvelope(payload: Uint8Array): AnyProtocolEnvelope | null {
+  return parseProtocolEnvelope(textDecoder.decode(payload));
+}


### PR DESCRIPTION
## Summary
- add one typed room protocol boundary for reliable publish, validation, and event routing
- migrate whisper and split sessions to the controller-owned DataReceived listener
- cover routing, publish failures, and three-client late-join snapshot hydration

## Validation
- `npm exec --yes pnpm@10.30.3 -- --filter frontend lint`
- `npm exec --yes pnpm@10.30.3 -- --filter frontend typecheck`
- `npm exec --yes pnpm@10.30.3 -- --filter frontend test`
- `npm exec --yes pnpm@10.30.3 -- --filter frontend build`
- Playwright: `whisper.spec.ts --grep "hydrates a late joiner"`

Closes #134