### PR TITLE
feat(room-session): add connection diagnostics

### DIFF
--- a/docs/plans/2026-07-09_room-diagnostics.md
+++ b/docs/plans/2026-07-09_room-diagnostics.md
@@ -1,0 +1,7 @@
+# In-room diagnostics implementation plan
+
+1. Add pure diagnostic snapshot, network-health, subscription, identifier, and redacted-summary helpers with focused unit tests.
+2. Add a room diagnostics hook for connection/reconnect history, LiveKit quality and receiver stats, local mic activity, device labels, and track subscription state.
+3. Add an accessible signal-ledger diagnostics drawer, expose it to every participant from the room top bar, and wire clipboard feedback through the room-session view model.
+4. Add a multi-client Playwright flow that opens the panel and verifies safe room/client and subscription information.
+5. Run pnpm 10.30.3 lint, typecheck, tests, build, and Playwright; review, commit, publish the PR, address feedback, and merge after CI passes.

--- a/frontend/e2e/whisper.spec.ts
+++ b/frontend/e2e/whisper.spec.ts
@@ -270,4 +270,33 @@ test.describe("whisper multi-client flows", () => {
       await bob.context.close();
     }
   });
+
+  test("opens room diagnostics with multi-client subscription state", async ({ browser }) => {
+    const alice = await openParticipant(browser, TEST_ROOM, "Alice");
+    const bob = await openParticipant(browser, TEST_ROOM, "Bob");
+
+    try {
+      await Promise.all([ensureCameraOn(alice.page), ensureCameraOn(bob.page)]);
+      await Promise.all([
+        waitForVideoPlayback(alice.page, bob.identity),
+        waitForVideoPlayback(bob.page, alice.identity)
+      ]);
+
+      await alice.page.getByRole("button", { name: "Diagnostics" }).click();
+      const diagnostics = alice.page.getByRole("dialog", { name: "Room Diagnostics" });
+      await expect(diagnostics).toBeVisible();
+      await expect(diagnostics.getByTestId("diagnostics-room-id")).toHaveText(TEST_ROOM);
+      await expect(diagnostics.getByTestId("diagnostics-client-id")).toHaveText(alice.identity);
+      await expect(diagnostics.getByTestId("diagnostics-main-audio")).toContainText("1/1");
+      await expect(diagnostics.getByTestId("diagnostics-whisper-audio")).toContainText("0/0");
+      await expect(diagnostics.getByTestId("diagnostics-video")).toContainText("1/1");
+      await expect(bob.page.getByRole("heading", { name: `Room: ${TEST_ROOM}` })).toBeVisible();
+
+      await diagnostics.getByRole("button", { name: "Close diagnostics" }).click();
+      await expect(diagnostics).not.toBeVisible();
+    } finally {
+      await alice.context.close();
+      await bob.context.close();
+    }
+  });
 });

--- a/frontend/src/features/room-session/components/DiagnosticsPanel.tsx
+++ b/frontend/src/features/room-session/components/DiagnosticsPanel.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useRef, useState } from "react";
+import { formatConnectionEvent, formatPacketLoss } from "@/features/room-session/lib/diagnostics";
+import type {
+  DiagnosticsHealthTone,
+  DiagnosticsPanelActions,
+  DiagnosticsPanelViewModel,
+  DiagnosticsSubscriptionState
+} from "@/features/room-session/types";
+
+type DiagnosticsPanelProps = {
+  model: DiagnosticsPanelViewModel;
+  actions: DiagnosticsPanelActions;
+};
+
+const TONE_CLASSES: Record<DiagnosticsHealthTone, string> = {
+  good: "bg-[var(--c-emerald)]",
+  watch: "bg-[var(--c-gold)]",
+  poor: "bg-[var(--c-ember)]",
+  unknown: "bg-[var(--c-text-faint)]"
+};
+
+export function DiagnosticsPanel({ model, actions: { onClose } }: DiagnosticsPanelProps) {
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "failed">("idle");
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  const copySummary = async () => {
+    try {
+      await copyText(model.summary);
+      setCopyStatus("copied");
+    } catch {
+      setCopyStatus("failed");
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex justify-end bg-black/70 backdrop-blur-[2px]"
+      data-testid="diagnostics-overlay"
+      onMouseDown={(event) => {
+        if (event.currentTarget === event.target) {
+          onClose();
+        }
+      }}
+      role="presentation"
+    >
+      <section
+        aria-labelledby="diagnostics-title"
+        aria-modal="true"
+        className="relative flex h-full w-full max-w-2xl flex-col overflow-hidden border-l border-[var(--c-rule-strong)] bg-[var(--c-ink)] shadow-[-24px_0_80px_rgba(0,0,0,0.45)]"
+        data-testid="diagnostics-panel"
+        role="dialog"
+      >
+        <div className="pointer-events-none absolute inset-0 opacity-40 [background-image:linear-gradient(rgba(255,255,255,0.018)_1px,transparent_1px)] [background-size:100%_28px]" />
+
+        <header className="relative flex items-start justify-between border-b border-[var(--c-rule-strong)] px-6 py-5 sm:px-8">
+          <div>
+            <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.22em] text-[var(--c-gold)]">
+              <span className={`h-1.5 w-1.5 rounded-full ${TONE_CLASSES[model.network.tone]} shadow-[0_0_12px_currentColor]`} />
+              Live signal ledger
+            </div>
+            <h2 id="diagnostics-title" className="display-face mt-2 text-lg text-[var(--c-text-warm)]">
+              Room Diagnostics
+            </h2>
+            <p className="mt-1 text-xs text-[var(--c-text-faint)]">
+              Safe telemetry for solving call trouble without exposing access credentials.
+            </p>
+          </div>
+          <button
+            aria-label="Close diagnostics"
+            className="act"
+            onClick={onClose}
+            ref={closeButtonRef}
+            type="button"
+          >
+            Close
+          </button>
+        </header>
+
+        <div className="diagnostics-scroll relative flex-1 overflow-y-auto px-6 py-6 sm:px-8">
+          <div className="grid gap-px border border-[var(--c-rule-strong)] bg-[var(--c-rule-strong)] sm:grid-cols-3">
+            <MetricCell
+              eyebrow="Connection"
+              value={humanize(model.connectionState)}
+              detail={`${Math.max(0, model.reconnectHistory.filter((entry) => entry.kind === "reconnected").length)} recoveries`}
+              tone={model.connectionState === "connected" ? "good" : "poor"}
+            />
+            <MetricCell
+              eyebrow="Network"
+              value={model.network.label}
+              detail={`Loss ${formatPacketLoss(model.network.packetLossPercent)}`}
+              tone={model.network.tone}
+            />
+            <div className="bg-[var(--c-slab)] p-4" data-testid="diagnostics-mic-meter">
+              <div className="flex items-center justify-between text-[10px] uppercase tracking-[0.12em] text-[var(--c-text-faint)]">
+                <span>Mic activity</span>
+                <span>{model.microphoneEnabled ? `${Math.round(model.microphoneLevel * 100)}%` : "Muted"}</span>
+              </div>
+              <div className="mt-3 h-1.5 overflow-hidden bg-[var(--c-void)]">
+                <div
+                  className={`h-full transition-[width] duration-150 ${model.microphoneEnabled ? "bg-[var(--c-emerald)]" : "bg-[var(--c-text-faint)]"}`}
+                  style={{ width: `${model.microphoneEnabled ? Math.max(2, model.microphoneLevel * 100) : 0}%` }}
+                />
+              </div>
+              <p className="mt-3 text-xs text-[var(--c-text-dim)]">
+                {model.microphoneEnabled ? "Listening for local speech" : "Main microphone is muted"}
+              </p>
+            </div>
+          </div>
+
+          <DiagnosticSection index="01" title="Media subscriptions">
+            <p className="mb-4 max-w-xl text-xs text-[var(--c-text-faint)]">
+              Published tracks are compared with streams this browser is actually receiving.
+            </p>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <SubscriptionCard label="Main audio" state={model.mainAudio} testId="diagnostics-main-audio" />
+              <SubscriptionCard label="Whisper audio" state={model.whisperAudio} testId="diagnostics-whisper-audio" />
+              <SubscriptionCard label="Video" state={model.video} testId="diagnostics-video" />
+            </div>
+          </DiagnosticSection>
+
+          <DiagnosticSection index="02" title="Active devices">
+            <dl className="divide-y divide-[var(--c-rule)] border-y border-[var(--c-rule)]">
+              <DeviceRow label="Microphone input" value={model.inputDeviceLabel} />
+              <DeviceRow label="Audio output" value={model.outputDeviceLabel} />
+              <DeviceRow label="Camera input" value={model.cameraDeviceLabel} />
+            </dl>
+          </DiagnosticSection>
+
+          <DiagnosticSection index="03" title="Connection history">
+            {model.reconnectHistory.length > 0 ? (
+              <ol className="relative ml-1 border-l border-[var(--c-rule-strong)] pl-5">
+                {model.reconnectHistory.map((entry, index) => (
+                  <li className="relative pb-4 last:pb-0" key={`${entry.kind}-${entry.at}-${index}`}>
+                    <span className={`absolute top-1 -left-[1.48rem] h-2 w-2 rounded-full border-2 border-[var(--c-ink)] ${entry.kind === "reconnecting" || entry.kind === "signal-reconnecting" ? "bg-[var(--c-ember)]" : "bg-[var(--c-emerald)]"}`} />
+                    <p className="text-xs text-[var(--c-text)]">{humanize(entry.kind)}</p>
+                    <p className="mt-0.5 font-mono text-[10px] text-[var(--c-text-faint)]">
+                      {formatConnectionEvent(entry).split(" at ")[1]}
+                    </p>
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <p className="text-xs text-[var(--c-text-faint)]">No connection events recorded.</p>
+            )}
+          </DiagnosticSection>
+
+          <DiagnosticSection index="04" title="Safe identifiers">
+            <dl className="grid gap-3 font-mono text-[11px] sm:grid-cols-2">
+              <div className="border border-[var(--c-rule)] bg-[var(--c-void)]/50 p-3">
+                <dt className="uppercase tracking-[0.1em] text-[var(--c-text-faint)]">Room</dt>
+                <dd className="mt-1 break-all text-[var(--c-text)]" data-testid="diagnostics-room-id">{model.roomName}</dd>
+              </div>
+              <div className="border border-[var(--c-rule)] bg-[var(--c-void)]/50 p-3">
+                <dt className="uppercase tracking-[0.1em] text-[var(--c-text-faint)]">Client</dt>
+                <dd className="mt-1 break-all text-[var(--c-text)]" data-testid="diagnostics-client-id">{model.clientIdentity}</dd>
+              </div>
+            </dl>
+          </DiagnosticSection>
+        </div>
+
+        <footer className="relative flex items-center justify-between gap-4 border-t border-[var(--c-rule-strong)] bg-[var(--c-void)]/80 px-6 py-4 sm:px-8">
+          <p aria-live="polite" className="text-[11px] text-[var(--c-text-faint)]">
+            {copyStatus === "copied" ? "Copied — paste this into a bug report." : copyStatus === "failed" ? "Copy failed. Check clipboard permissions." : `Captured ${new Date(model.capturedAt).toLocaleTimeString()}`}
+          </p>
+          <button className="chip" data-testid="copy-diagnostics" onClick={() => void copySummary()} type="button">
+            Copy redacted summary
+          </button>
+        </footer>
+      </section>
+    </div>
+  );
+}
+
+function MetricCell({
+  eyebrow,
+  value,
+  detail,
+  tone
+}: {
+  eyebrow: string;
+  value: string;
+  detail: string;
+  tone: DiagnosticsHealthTone;
+}) {
+  return (
+    <div className="bg-[var(--c-slab)] p-4">
+      <p className="text-[10px] uppercase tracking-[0.12em] text-[var(--c-text-faint)]">{eyebrow}</p>
+      <div className="mt-2 flex items-center gap-2">
+        <span className={`h-1.5 w-1.5 rounded-full ${TONE_CLASSES[tone]}`} />
+        <p className="display-face text-sm text-[var(--c-text-warm)]">{value}</p>
+      </div>
+      <p className="mt-2 text-xs text-[var(--c-text-dim)]">{detail}</p>
+    </div>
+  );
+}
+
+function DiagnosticSection({ index, title, children }: { index: string; title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-8">
+      <div className="mb-4 flex items-baseline gap-3 border-b border-[var(--c-rule)] pb-2">
+        <span className="font-mono text-[10px] text-[var(--c-gold)]">{index}</span>
+        <h3 className="display-face text-xs tracking-[0.08em] text-[var(--c-text-warm)]">{title}</h3>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function SubscriptionCard({ label, state, testId }: { label: string; state: DiagnosticsSubscriptionState; testId: string }) {
+  const healthy = state.published === state.subscribed;
+  return (
+    <article className="border border-[var(--c-rule)] bg-[var(--c-slab)] p-4" data-testid={testId}>
+      <div className="flex items-center justify-between gap-2">
+        <h4 className="text-[11px] uppercase tracking-[0.08em] text-[var(--c-text-dim)]">{label}</h4>
+        <span className={`h-1.5 w-1.5 rounded-full ${healthy ? "bg-[var(--c-emerald)]" : "bg-[var(--c-gold)]"}`} />
+      </div>
+      <p className="display-face mt-4 text-2xl text-[var(--c-text-warm)]">
+        {state.subscribed}<span className="text-sm text-[var(--c-text-faint)]">/{state.published}</span>
+      </p>
+      <p className="mt-1 text-[11px] text-[var(--c-text-faint)]">
+        receiving · {state.muted} muted
+      </p>
+    </article>
+  );
+}
+
+function DeviceRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid gap-1 py-3 sm:grid-cols-[10rem_1fr] sm:gap-4">
+      <dt className="text-[10px] uppercase tracking-[0.1em] text-[var(--c-text-faint)]">{label}</dt>
+      <dd className="truncate text-xs text-[var(--c-text)]" title={value}>{value}</dd>
+    </div>
+  );
+}
+
+function humanize(value: string): string {
+  return value.replace(/([a-z])([A-Z])/g, "$1 $2").replaceAll("-", " ").replace(/^./, (letter) => letter.toUpperCase());
+}
+
+async function copyText(value: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(value);
+      return;
+    } catch {
+      // Fall through for browsers that expose Clipboard API without granting permission.
+    }
+  }
+
+  const textArea = document.createElement("textarea");
+  textArea.value = value;
+  textArea.style.position = "fixed";
+  textArea.style.opacity = "0";
+  document.body.appendChild(textArea);
+  textArea.select();
+  const copied = document.execCommand("copy");
+  textArea.remove();
+  if (!copied) {
+    throw new Error("Clipboard unavailable");
+  }
+}

--- a/frontend/src/features/room-session/components/RoomSessionController.tsx
+++ b/frontend/src/features/room-session/components/RoomSessionController.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { DevicePanel } from "@/features/room-session/components/DevicePanel";
+import { DiagnosticsPanel } from "@/features/room-session/components/DiagnosticsPanel";
 import { ParticipantRoster } from "@/features/room-session/components/ParticipantRoster";
 import { RemoteAudioLayer } from "@/features/room-session/components/RemoteAudioLayer";
 import { RoomSessionLayout } from "@/features/room-session/components/RoomSessionLayout";
@@ -41,29 +42,32 @@ export function RoomSessionController({ roomName, displayName }: RoomSessionCont
   ) : undefined;
 
   return (
-    <RoomSessionLayout
-      header={<RoomTopBar {...viewModel.topBar} />}
-      main={<VideoGrid {...viewModel.videoGrid} />}
-      sidebar={
-        <SessionSidebar
-          open={viewModel.sidebar.open}
-          splitPanel={splitPanel}
-          whisperPanel={<WhisperPanel {...viewModel.sidebar.whisperPanel} />}
-          rosterPanel={
-            <ParticipantRoster
-              participantRoster={viewModel.sidebar.participantRoster.items}
-              title={viewModel.sidebar.participantRoster.title}
-            />
-          }
-          devicePanel={<DevicePanel {...viewModel.sidebar.devicePanel} />}
-        />
-      }
-      audioLayer={
-        <RemoteAudioLayer
-          audioTracks={viewModel.audioLayer.tracks}
-          mainVolume={viewModel.audioLayer.mainVolume}
-        />
-      }
-    />
+    <>
+      <RoomSessionLayout
+        header={<RoomTopBar {...viewModel.topBar} />}
+        main={<VideoGrid {...viewModel.videoGrid} />}
+        sidebar={
+          <SessionSidebar
+            open={viewModel.sidebar.open}
+            splitPanel={splitPanel}
+            whisperPanel={<WhisperPanel {...viewModel.sidebar.whisperPanel} />}
+            rosterPanel={
+              <ParticipantRoster
+                participantRoster={viewModel.sidebar.participantRoster.items}
+                title={viewModel.sidebar.participantRoster.title}
+              />
+            }
+            devicePanel={<DevicePanel {...viewModel.sidebar.devicePanel} />}
+          />
+        }
+        audioLayer={
+          <RemoteAudioLayer
+            audioTracks={viewModel.audioLayer.tracks}
+            mainVolume={viewModel.audioLayer.mainVolume}
+          />
+        }
+      />
+      {viewModel.diagnostics.open ? <DiagnosticsPanel {...viewModel.diagnostics.panel} /> : null}
+    </>
   );
 }

--- a/frontend/src/features/room-session/components/RoomTopBar.tsx
+++ b/frontend/src/features/room-session/components/RoomTopBar.tsx
@@ -21,7 +21,7 @@ export function RoomTopBar({
     followSpotlight,
     sidebarOpen
   },
-  actions: { onToggleMic, onToggleCamera, onFollowSpotlightChange, onToggleSidebar, onLeave }
+  actions: { onToggleMic, onToggleCamera, onFollowSpotlightChange, onToggleSidebar, onOpenDiagnostics, onLeave }
 }: RoomTopBarProps) {
   return (
     <header className="z-20 flex shrink-0 items-center justify-between gap-6 bg-[var(--c-ink)] px-5 py-2">
@@ -82,6 +82,10 @@ export function RoomTopBar({
         </label>
         <button className="act" onClick={onToggleSidebar} type="button">
           {sidebarOpen ? "Close" : "Panel"}
+        </button>
+        <button aria-haspopup="dialog" className="act act--emerald" onClick={onOpenDiagnostics} type="button">
+          <span className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--c-emerald)] shadow-[0_0_8px_var(--c-emerald)]" />
+          Diagnostics
         </button>
 
         <span className="h-3 w-px bg-[var(--c-rule)]" />

--- a/frontend/src/features/room-session/hooks/useRoomDiagnostics.ts
+++ b/frontend/src/features/room-session/hooks/useRoomDiagnostics.ts
@@ -1,0 +1,282 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ConnectionQuality, Room, RoomEvent, Track } from "livekit-client";
+import type { Participant, RemoteAudioTrack, RemoteVideoTrack } from "livekit-client";
+import {
+  deriveNetworkHealth,
+  formatDiagnosticSummary
+} from "@/features/room-session/lib/diagnostics";
+import type {
+  DiagnosticsConnectionEvent,
+  DiagnosticsConnectionEventKind,
+  DiagnosticsPanelViewModel,
+  DiagnosticsSubscriptionState
+} from "@/features/room-session/types";
+
+type UseRoomDiagnosticsInput = {
+  room: Room | null;
+  roomName: string;
+  clientIdentity: string;
+  open: boolean;
+  renderVersion: number;
+  microphoneEnabled: boolean;
+  audioDevices: ReadonlyArray<MediaDeviceInfo>;
+  selectedAudioDevice: string;
+  videoDevices: ReadonlyArray<MediaDeviceInfo>;
+  selectedVideoDevice: string;
+};
+
+const EMPTY_SUBSCRIPTIONS: DiagnosticsSubscriptionState = {
+  published: 0,
+  subscribed: 0,
+  muted: 0
+};
+
+export function useRoomDiagnostics({
+  room,
+  roomName,
+  clientIdentity,
+  open,
+  renderVersion,
+  microphoneEnabled,
+  audioDevices,
+  selectedAudioDevice,
+  videoDevices,
+  selectedVideoDevice
+}: UseRoomDiagnosticsInput): DiagnosticsPanelViewModel {
+  const [capturedAt, setCapturedAt] = useState(() => Date.now());
+  const [reconnectHistory, setReconnectHistory] = useState<DiagnosticsConnectionEvent[]>([]);
+  const [microphoneLevel, setMicrophoneLevel] = useState(0);
+  const [packetLossPercent, setPacketLossPercent] = useState<number | null>(null);
+  const [livekitQuality, setLivekitQuality] = useState<string>(ConnectionQuality.Unknown);
+  const [outputDevices, setOutputDevices] = useState<MediaDeviceInfo[]>([]);
+  const [snapshotVersion, setSnapshotVersion] = useState(0);
+
+  useEffect(() => {
+    if (!room) {
+      setReconnectHistory([]);
+      setLivekitQuality(ConnectionQuality.Unknown);
+      setPacketLossPercent(null);
+      setOutputDevices([]);
+      return;
+    }
+
+    setCapturedAt(Date.now());
+    setPacketLossPercent(null);
+    setReconnectHistory([{ kind: "connected", at: Date.now() }]);
+    setLivekitQuality(room.localParticipant.connectionQuality);
+
+    const record = (kind: DiagnosticsConnectionEventKind) => {
+      setReconnectHistory((current) => [
+        ...current.slice(-9),
+        { kind, at: Date.now() }
+      ]);
+      setCapturedAt(Date.now());
+    };
+    const onConnectionQualityChanged = (quality: ConnectionQuality, participant: Participant) => {
+      if (participant.identity === room.localParticipant.identity) {
+        setLivekitQuality(quality);
+        setCapturedAt(Date.now());
+      }
+    };
+    const onSignalReconnecting = () => record("signal-reconnecting");
+    const onReconnecting = () => record("reconnecting");
+    const onReconnected = () => record("reconnected");
+
+    room.on(RoomEvent.SignalReconnecting, onSignalReconnecting);
+    room.on(RoomEvent.Reconnecting, onReconnecting);
+    room.on(RoomEvent.Reconnected, onReconnected);
+    room.on(RoomEvent.ConnectionQualityChanged, onConnectionQualityChanged);
+
+    return () => {
+      room.off(RoomEvent.SignalReconnecting, onSignalReconnecting);
+      room.off(RoomEvent.Reconnecting, onReconnecting);
+      room.off(RoomEvent.Reconnected, onReconnected);
+      room.off(RoomEvent.ConnectionQualityChanged, onConnectionQualityChanged);
+    };
+  }, [room]);
+
+  useEffect(() => {
+    if (!room || !open) {
+      setMicrophoneLevel(0);
+      return;
+    }
+
+    const refreshMicrophoneLevel = () => {
+      setMicrophoneLevel(clamp(room.localParticipant.audioLevel, 0, 1));
+    };
+    refreshMicrophoneLevel();
+    const timer = window.setInterval(refreshMicrophoneLevel, 150);
+    return () => window.clearInterval(timer);
+  }, [open, room]);
+
+  useEffect(() => {
+    if (!room || !open) {
+      return;
+    }
+
+    let cancelled = false;
+    const refresh = async () => {
+      const nextPacketLoss = await collectReceiverPacketLoss(room);
+      if (cancelled) {
+        return;
+      }
+      setPacketLossPercent(nextPacketLoss);
+      setCapturedAt(Date.now());
+      setSnapshotVersion((current) => current + 1);
+    };
+
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), 2500);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [open, room]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    let cancelled = false;
+    const loadOutputDevices = async () => {
+      try {
+        const devices = await Room.getLocalDevices("audiooutput");
+        if (!cancelled) {
+          setOutputDevices(devices);
+        }
+      } catch {
+        if (!cancelled) {
+          setOutputDevices([]);
+        }
+      }
+    };
+
+    void loadOutputDevices();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, room]);
+
+  const subscriptions = useMemo(() => {
+    const version = renderVersion + snapshotVersion;
+    void version;
+    return collectSubscriptionStates(room);
+  }, [renderVersion, room, snapshotVersion]);
+  const connectionState = room?.state ?? "disconnected";
+  const network = deriveNetworkHealth({
+    connectionState,
+    livekitQuality,
+    packetLossPercent
+  });
+  const outputDeviceId = room?.getActiveDevice("audiooutput") ?? "default";
+  const snapshot: Omit<DiagnosticsPanelViewModel, "summary"> = {
+    capturedAt,
+    roomName,
+    clientIdentity,
+    connectionState,
+    reconnectHistory,
+    network,
+    microphoneLevel,
+    microphoneEnabled,
+    inputDeviceLabel: resolveDeviceLabel(audioDevices, selectedAudioDevice, "Microphone unavailable"),
+    outputDeviceLabel: resolveDeviceLabel(outputDevices, outputDeviceId, "Browser default / unavailable"),
+    cameraDeviceLabel: resolveDeviceLabel(videoDevices, selectedVideoDevice, "Camera unavailable"),
+    mainAudio: subscriptions.mainAudio,
+    whisperAudio: subscriptions.whisperAudio,
+    video: subscriptions.video
+  };
+
+  return {
+    ...snapshot,
+    summary: formatDiagnosticSummary(snapshot)
+  };
+}
+
+function collectSubscriptionStates(room: Room | null): {
+  mainAudio: DiagnosticsSubscriptionState;
+  whisperAudio: DiagnosticsSubscriptionState;
+  video: DiagnosticsSubscriptionState;
+} {
+  if (!room) {
+    return {
+      mainAudio: { ...EMPTY_SUBSCRIPTIONS },
+      whisperAudio: { ...EMPTY_SUBSCRIPTIONS },
+      video: { ...EMPTY_SUBSCRIPTIONS }
+    };
+  }
+
+  const result = {
+    mainAudio: { ...EMPTY_SUBSCRIPTIONS },
+    whisperAudio: { ...EMPTY_SUBSCRIPTIONS },
+    video: { ...EMPTY_SUBSCRIPTIONS }
+  };
+
+  room.remoteParticipants.forEach((participant) => {
+    participant.trackPublications.forEach((publication) => {
+      const state = publication.kind === Track.Kind.Video
+        ? result.video
+        : publication.trackName.startsWith("whisper:")
+          ? result.whisperAudio
+          : result.mainAudio;
+      state.published += 1;
+      state.subscribed += publication.isSubscribed ? 1 : 0;
+      state.muted += publication.isMuted ? 1 : 0;
+    });
+  });
+
+  return result;
+}
+
+async function collectReceiverPacketLoss(room: Room): Promise<number | null> {
+  const statsPromises: Array<Promise<{ packetsLost?: number; packetsReceived?: number } | undefined>> = [];
+
+  room.remoteParticipants.forEach((participant) => {
+    participant.trackPublications.forEach((publication) => {
+      if (!publication.isSubscribed || !publication.track) {
+        return;
+      }
+
+      if (publication.kind === Track.Kind.Audio) {
+        statsPromises.push((publication.track as RemoteAudioTrack).getReceiverStats());
+      } else if (publication.kind === Track.Kind.Video) {
+        statsPromises.push((publication.track as RemoteVideoTrack).getReceiverStats());
+      }
+    });
+  });
+
+  if (statsPromises.length === 0) {
+    return null;
+  }
+
+  const settled = await Promise.allSettled(statsPromises);
+  let packetsLost = 0;
+  let packetsReceived = 0;
+  settled.forEach((result) => {
+    if (result.status !== "fulfilled" || !result.value) {
+      return;
+    }
+    packetsLost += Math.max(0, result.value.packetsLost ?? 0);
+    packetsReceived += Math.max(0, result.value.packetsReceived ?? 0);
+  });
+
+  const total = packetsLost + packetsReceived;
+  return total > 0 ? (packetsLost / total) * 100 : null;
+}
+
+function resolveDeviceLabel(
+  devices: ReadonlyArray<MediaDeviceInfo>,
+  selectedDeviceId: string,
+  fallback: string
+): string {
+  const selected = devices.find((device) => device.deviceId === selectedDeviceId)
+    ?? (selectedDeviceId === "default" ? devices.find((device) => device.deviceId === "default") : undefined)
+    ?? devices[0];
+  return selected?.label || fallback;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value));
+}

--- a/frontend/src/features/room-session/hooks/useRoomSessionViewModel.ts
+++ b/frontend/src/features/room-session/hooks/useRoomSessionViewModel.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { useRoomConnection } from "@/features/room-session/hooks/useRoomConnection";
+import { useRoomDiagnostics } from "@/features/room-session/hooks/useRoomDiagnostics";
 import { useRoomMedia } from "@/features/room-session/hooks/useRoomMedia";
 import { useRoomParticipants } from "@/features/room-session/hooks/useRoomParticipants";
 import { useRoomProtocol } from "@/features/room-session/hooks/useRoomProtocol";
@@ -35,6 +36,7 @@ function commandResult(ok: boolean): CommandResult {
 
 export function useRoomSessionViewModel({ roomName, displayName }: UseRoomSessionViewModelInput) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
 
   const connection = useRoomConnection({ roomName, displayName });
   const media = useRoomMedia({ room: connection.room });
@@ -44,6 +46,18 @@ export function useRoomSessionViewModel({ roomName, displayName }: UseRoomSessio
     identity: connection.identity,
     renderVersion: connection.renderVersion,
     displayName
+  });
+  const diagnostics = useRoomDiagnostics({
+    room: connection.room,
+    roomName,
+    clientIdentity: connection.identity,
+    open: diagnosticsOpen,
+    renderVersion: connection.renderVersion,
+    microphoneEnabled: media.micEnabled,
+    audioDevices: media.audioDevices,
+    selectedAudioDevice: media.selectedAudioDevice,
+    videoDevices: media.videoDevices,
+    selectedVideoDevice: media.selectedVideoDevice
   });
   const splitSession = useSplitRoomSession({
     room: connection.room,
@@ -118,6 +132,8 @@ export function useRoomSessionViewModel({ roomName, displayName }: UseRoomSessio
   );
 
   const toggleSidebar = useCallback(() => setSidebarOpen((current) => !current), []);
+  const openDiagnostics = useCallback(() => setDiagnosticsOpen(true), []);
+  const closeDiagnostics = useCallback(() => setDiagnosticsOpen(false), []);
   const {
     addRoom,
     assignParticipantToRoom,
@@ -173,6 +189,7 @@ export function useRoomSessionViewModel({ roomName, displayName }: UseRoomSessio
       onToggleCamera: media.toggleCamera,
       onFollowSpotlightChange: whisperSession.setFollowSpotlight,
       onToggleSidebar: toggleSidebar,
+      onOpenDiagnostics: openDiagnostics,
       onLeave: connection.disconnect
     } satisfies RoomTopBarActions
   };
@@ -268,6 +285,15 @@ export function useRoomSessionViewModel({ roomName, displayName }: UseRoomSessio
     audioLayer: {
       tracks: collections.visibleAudioTracks,
       mainVolume: whisperSession.mainVolume
+    },
+    diagnostics: {
+      open: diagnosticsOpen,
+      panel: {
+        model: diagnostics,
+        actions: {
+          onClose: closeDiagnostics
+        }
+      }
     }
   };
 }

--- a/frontend/src/features/room-session/lib/diagnostics.test.ts
+++ b/frontend/src/features/room-session/lib/diagnostics.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveNetworkHealth,
+  formatDiagnosticSummary,
+  redactDiagnosticText,
+  safeDiagnosticIdentifier
+} from "@/features/room-session/lib/diagnostics";
+
+describe("diagnostic formatting", () => {
+  it("formats a safe, actionable summary", () => {
+    const summary = formatDiagnosticSummary({
+      capturedAt: Date.parse("2026-07-09T20:00:00.000Z"),
+      roomName: "Thursday Table",
+      clientIdentity: "u_client-42",
+      connectionState: "connected",
+      reconnectHistory: [
+        { kind: "connected", at: Date.parse("2026-07-09T19:58:00.000Z") },
+        { kind: "reconnected", at: Date.parse("2026-07-09T19:59:00.000Z") }
+      ],
+      network: deriveNetworkHealth({
+        connectionState: "connected",
+        livekitQuality: "excellent",
+        packetLossPercent: 0.25
+      }),
+      microphoneLevel: 0.42,
+      microphoneEnabled: true,
+      inputDeviceLabel: "Table microphone",
+      outputDeviceLabel: "Headphones",
+      cameraDeviceLabel: "Front camera",
+      mainAudio: { published: 2, subscribed: 2, muted: 0 },
+      whisperAudio: { published: 1, subscribed: 1, muted: 1 },
+      video: { published: 2, subscribed: 1, muted: 0 }
+    });
+
+    expect(summary).toContain("Room: Thursday_Table");
+    expect(summary).toContain("Client: u_client-42");
+    expect(summary).toContain("packet loss 0.3%");
+    expect(summary).toContain("Whisper audio subscriptions: 1/1 subscribed; 1 muted");
+    expect(summary).toContain("Reconnected at 2026-07-09T19:59:00.000Z");
+  });
+
+  it("redacts tokens, authorization values, and secrets from report fields", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwbGF5ZXIifQ.signature123";
+    const value = [
+      `token=${jwt}`,
+      "Authorization: Bearer super-secret-value",
+      "https://example.invalid?access_token=abc123&room=safe",
+      "client_secret=never-copy-this"
+    ].join("\n");
+
+    const redacted = redactDiagnosticText(value);
+    expect(redacted).not.toContain(jwt);
+    expect(redacted).not.toContain("super-secret-value");
+    expect(redacted).not.toContain("abc123");
+    expect(redacted).not.toContain("never-copy-this");
+    expect(redacted).toContain("[REDACTED]");
+  });
+
+  it("sanitizes and bounds room/client identifiers", () => {
+    expect(safeDiagnosticIdentifier("  table / secret?  ")).toBe("table___secret_");
+    expect(safeDiagnosticIdentifier("x".repeat(120))).toHaveLength(80);
+    expect(safeDiagnosticIdentifier("   ")).toBe("unknown");
+  });
+});
+
+describe("network health", () => {
+  it("prioritizes reconnection and poor packet-loss states", () => {
+    expect(
+      deriveNetworkHealth({
+        connectionState: "reconnecting",
+        livekitQuality: "excellent",
+        packetLossPercent: 0
+      }).tone
+    ).toBe("poor");
+    expect(
+      deriveNetworkHealth({
+        connectionState: "connected",
+        livekitQuality: "excellent",
+        packetLossPercent: 7.5
+      }).label
+    ).toBe("Poor");
+  });
+});

--- a/frontend/src/features/room-session/lib/diagnostics.ts
+++ b/frontend/src/features/room-session/lib/diagnostics.ts
@@ -1,0 +1,135 @@
+import type {
+  DiagnosticsConnectionEvent,
+  DiagnosticsConnectionEventKind,
+  DiagnosticsNetworkHealth,
+  DiagnosticsPanelViewModel,
+  DiagnosticsSubscriptionState
+} from "@/features/room-session/types";
+
+type DeriveNetworkHealthInput = {
+  connectionState: string;
+  livekitQuality: string;
+  packetLossPercent: number | null;
+};
+
+type DiagnosticSummaryInput = Omit<DiagnosticsPanelViewModel, "summary">;
+
+const CONNECTION_EVENT_LABELS: Record<DiagnosticsConnectionEventKind, string> = {
+  connected: "Connected",
+  "signal-reconnecting": "Signal reconnecting",
+  reconnecting: "Media reconnecting",
+  reconnected: "Reconnected"
+};
+
+export function deriveNetworkHealth({
+  connectionState,
+  livekitQuality,
+  packetLossPercent
+}: DeriveNetworkHealthInput): DiagnosticsNetworkHealth {
+  const normalizedQuality = livekitQuality.toLowerCase();
+  const normalizedState = connectionState.toLowerCase();
+
+  if (normalizedState.includes("reconnecting") || normalizedState === "disconnected") {
+    return {
+      tone: "poor",
+      label: normalizedState === "disconnected" ? "Offline" : "Recovering",
+      detail: "The room connection is not currently stable.",
+      livekitQuality: normalizedQuality || "unknown",
+      packetLossPercent
+    };
+  }
+
+  if (normalizedQuality === "lost" || normalizedQuality === "poor" || (packetLossPercent ?? 0) >= 5) {
+    return {
+      tone: "poor",
+      label: "Poor",
+      detail: "Audio or video may break up. Check the network path.",
+      livekitQuality: normalizedQuality || "unknown",
+      packetLossPercent
+    };
+  }
+
+  if (normalizedQuality === "good" || (packetLossPercent ?? 0) >= 2) {
+    return {
+      tone: "watch",
+      label: "Watch",
+      detail: "Usable, with signs of network pressure.",
+      livekitQuality: normalizedQuality || "unknown",
+      packetLossPercent
+    };
+  }
+
+  if (normalizedQuality === "excellent" || packetLossPercent !== null) {
+    return {
+      tone: "good",
+      label: "Stable",
+      detail: "The current media path looks healthy.",
+      livekitQuality: normalizedQuality || "unknown",
+      packetLossPercent
+    };
+  }
+
+  return {
+    tone: "unknown",
+    label: "Measuring",
+    detail: "Waiting for enough receiver data.",
+    livekitQuality: normalizedQuality || "unknown",
+    packetLossPercent
+  };
+}
+
+export function formatDiagnosticSummary(snapshot: DiagnosticSummaryInput): string {
+  const lines = [
+    "Fliesentisch room diagnostics",
+    `Captured: ${new Date(snapshot.capturedAt).toISOString()}`,
+    `Room: ${safeDiagnosticIdentifier(snapshot.roomName)}`,
+    `Client: ${safeDiagnosticIdentifier(snapshot.clientIdentity)}`,
+    `Connection: ${snapshot.connectionState}`,
+    `Network: ${snapshot.network.label} (LiveKit ${snapshot.network.livekitQuality}; packet loss ${formatPacketLoss(snapshot.network.packetLossPercent)})`,
+    `Microphone: ${snapshot.microphoneEnabled ? "enabled" : "muted"}; activity ${formatPercentage(snapshot.microphoneLevel * 100)}`,
+    `Input device: ${snapshot.inputDeviceLabel}`,
+    `Output device: ${snapshot.outputDeviceLabel}`,
+    `Camera device: ${snapshot.cameraDeviceLabel}`,
+    `Main audio subscriptions: ${formatSubscriptionState(snapshot.mainAudio)}`,
+    `Whisper audio subscriptions: ${formatSubscriptionState(snapshot.whisperAudio)}`,
+    `Video subscriptions: ${formatSubscriptionState(snapshot.video)}`,
+    `Reconnect history: ${formatConnectionHistory(snapshot.reconnectHistory)}`
+  ];
+
+  return redactDiagnosticText(lines.join("\n"));
+}
+
+export function formatConnectionEvent(event: DiagnosticsConnectionEvent): string {
+  return `${CONNECTION_EVENT_LABELS[event.kind]} at ${new Date(event.at).toISOString()}`;
+}
+
+export function formatPacketLoss(value: number | null): string {
+  return value === null ? "unavailable" : formatPercentage(value);
+}
+
+export function safeDiagnosticIdentifier(value: string): string {
+  const normalized = value.trim().replace(/[^a-zA-Z0-9._:-]/g, "_").slice(0, 80);
+  return normalized || "unknown";
+}
+
+export function redactDiagnosticText(value: string): string {
+  return value
+    .replace(/\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g, "[REDACTED_JWT]")
+    .replace(/([?&](?:access_token|auth|token)=)[^&\s]+/gi, "$1[REDACTED]")
+    .replace(/((?:authorization|password|secret|token)\s*[:=]\s*)(?:bearer\s+)?[^\s;]+/gi, "$1[REDACTED]");
+}
+
+function formatPercentage(value: number): string {
+  return `${Math.max(0, value).toFixed(1)}%`;
+}
+
+function formatSubscriptionState(state: DiagnosticsSubscriptionState): string {
+  return `${state.subscribed}/${state.published} subscribed; ${state.muted} muted`;
+}
+
+function formatConnectionHistory(history: ReadonlyArray<DiagnosticsConnectionEvent>): string {
+  if (history.length === 0) {
+    return "none recorded";
+  }
+  return history.map(formatConnectionEvent).join(" | ");
+}

--- a/frontend/src/features/room-session/types.ts
+++ b/frontend/src/features/room-session/types.ts
@@ -48,6 +48,7 @@ export type RoomTopBarActions = {
   onToggleCamera: () => Promise<void>;
   onFollowSpotlightChange: (follow: boolean) => void;
   onToggleSidebar: () => void;
+  onOpenDiagnostics: () => void;
   onLeave: () => void;
 };
 
@@ -124,4 +125,53 @@ export type DevicePanelActions = {
   onMirrorSelfViewChange: (mirrored: boolean) => void;
   onSelectAudioDevice: (deviceId: string) => Promise<void>;
   onSelectVideoDevice: (deviceId: string) => Promise<void>;
+};
+
+export type DiagnosticsHealthTone = "good" | "watch" | "poor" | "unknown";
+
+export type DiagnosticsConnectionEventKind =
+  | "connected"
+  | "signal-reconnecting"
+  | "reconnecting"
+  | "reconnected";
+
+export type DiagnosticsConnectionEvent = {
+  kind: DiagnosticsConnectionEventKind;
+  at: number;
+};
+
+export type DiagnosticsNetworkHealth = {
+  tone: DiagnosticsHealthTone;
+  label: string;
+  detail: string;
+  livekitQuality: string;
+  packetLossPercent: number | null;
+};
+
+export type DiagnosticsSubscriptionState = {
+  published: number;
+  subscribed: number;
+  muted: number;
+};
+
+export type DiagnosticsPanelViewModel = {
+  capturedAt: number;
+  roomName: string;
+  clientIdentity: string;
+  connectionState: string;
+  reconnectHistory: ReadonlyArray<DiagnosticsConnectionEvent>;
+  network: DiagnosticsNetworkHealth;
+  microphoneLevel: number;
+  microphoneEnabled: boolean;
+  inputDeviceLabel: string;
+  outputDeviceLabel: string;
+  cameraDeviceLabel: string;
+  mainAudio: DiagnosticsSubscriptionState;
+  whisperAudio: DiagnosticsSubscriptionState;
+  video: DiagnosticsSubscriptionState;
+  summary: string;
+};
+
+export type DiagnosticsPanelActions = {
+  onClose: () => void;
 };

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -240,3 +240,12 @@ input, select, button { font: inherit; }
   background: rgba(255, 255, 255, 0.08);
   border-radius: 2px;
 }
+
+.diagnostics-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(201, 150, 62, 0.28) transparent;
+}
+
+.diagnostics-scroll::-webkit-scrollbar { width: 5px; }
+.diagnostics-scroll::-webkit-scrollbar-track { background: transparent; }
+.diagnostics-scroll::-webkit-scrollbar-thumb { background: rgba(201, 150, 62, 0.28); }


### PR DESCRIPTION
## Summary
- add an in-room signal ledger with connection/reconnect history, device labels, mic activity, and distinct main/whisper/video subscriptions
- derive high-level LiveKit network health from connection quality and receiver packet-loss stats
- provide a copyable, allowlisted and redacted diagnostic summary with safe room/client identifiers

## Validation
- `npm exec --yes pnpm@10.30.3 -- --filter frontend lint`
- `npm exec --yes pnpm@10.30.3 -- --filter frontend typecheck`
- `npm exec --yes pnpm@10.30.3 -- --filter frontend test`
- `npm exec --yes pnpm@10.30.3 -- --filter frontend build`
- Playwright: two-client diagnostics subscription state
- headed Playwright CLI: layout, reconnect history, Escape close, and clipboard fallback

Closes #130