### PR TITLE
feat(room-session): add handout spotlight

### DIFF
--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -106,7 +106,7 @@ mod tests {
         auth::{random_token, signed_value, SESSION_COOKIE_NAME},
         config::{parse_optional_set, AppConfig},
         token::{derive_room_identity, LiveKitClaims, TokenResponse},
-        users::{build_bootstrap_users, CampaignPreset, UserStore},
+        users::{build_bootstrap_users, CampaignPreset, PlatformRole, UserStore},
     };
     use axum::{body::Body, http::Request, http::StatusCode};
     use chrono::{Duration, Utc};
@@ -299,6 +299,15 @@ mod tests {
         .unwrap();
         assert_eq!(decoded.claims.video.room, "dnd-table-1");
         assert_eq!(decoded.claims.sub, parsed.identity);
+        assert_eq!(
+            decoded.claims.attributes.get("game_role"),
+            Some(&"player".to_string())
+        );
+        assert_eq!(
+            decoded.claims.attributes.get("platform_role"),
+            Some(&"user".to_string())
+        );
+        assert_eq!(parsed.platform_role, PlatformRole::User);
         assert_eq!(
             parsed.identity,
             derive_room_identity(&state.config.cookie_secret, "google-player").unwrap()
@@ -602,6 +611,16 @@ mod tests {
                 .unwrap();
             let token: TokenResponse = serde_json::from_slice(&body).unwrap();
             assert_eq!(token.game_role, expected_role);
+            let decoded = decode::<LiveKitClaims>(
+                &token.token,
+                &DecodingKey::from_secret("devsecret".as_bytes()),
+                &Validation::new(Algorithm::HS256),
+            )
+            .unwrap();
+            assert_eq!(
+                decoded.claims.attributes.get("game_role"),
+                Some(&expected_role.as_str().to_string())
+            );
         }
     }
 

--- a/backend/src/token.rs
+++ b/backend/src/token.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
@@ -50,6 +50,7 @@ pub(crate) struct TokenResponse {
     pub(crate) expires_at: DateTime<Utc>,
     pub(crate) identity: String,
     pub(crate) game_role: GameRole,
+    pub(crate) platform_role: PlatformRole,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -59,6 +60,7 @@ pub(crate) struct LiveKitClaims {
     pub(crate) name: String,
     pub(crate) nbf: i64,
     pub(crate) exp: i64,
+    pub(crate) attributes: BTreeMap<String, String>,
     pub(crate) video: LiveKitVideoGrant,
 }
 
@@ -134,6 +136,16 @@ pub(crate) async fn mint_token(
     let now = Utc::now();
     let expiry = token_expiry(now, state.config.token_ttl_seconds)?;
 
+    let attributes = BTreeMap::from([
+        (
+            "game_role".to_string(),
+            effective_game_role.as_str().to_string(),
+        ),
+        (
+            "platform_role".to_string(),
+            updated_user.platform_role.as_str().to_string(),
+        ),
+    ]);
     let claims = LiveKitClaims {
         iss: state.config.livekit_api_key.clone(),
         sub: opaque_identity,
@@ -142,6 +154,7 @@ pub(crate) async fn mint_token(
             .unwrap_or_else(|| nickname.to_string()),
         nbf: now.timestamp(),
         exp: expiry.timestamp(),
+        attributes,
         video: LiveKitVideoGrant {
             room_join: true,
             room,
@@ -164,6 +177,7 @@ pub(crate) async fn mint_token(
             expires_at: expiry,
             identity: claims.sub,
             game_role: effective_game_role,
+            platform_role: updated_user.platform_role,
         }),
     ))
 }

--- a/docs/contracts/datachannel-protocol.md
+++ b/docs/contracts/datachannel-protocol.md
@@ -4,7 +4,7 @@ All messages are JSON objects:
 
 ```json
 {
-  "type": "STATE_REQUEST|STATE_SNAPSHOT|WHISPER_CREATE|WHISPER_UPDATE|WHISPER_CLOSE|SPOTLIGHT_UPDATE|SPLIT_STATE_REQUEST|SPLIT_STATE_SNAPSHOT|SPLIT_START|SPLIT_END|SPLIT_ROOM_UPSERT|SPLIT_ROOM_REMOVE|SPLIT_ASSIGNMENT_SET|SPLIT_GM_FOCUS_UPDATE|SPLIT_GM_BROADCAST_UPDATE",
+  "type": "STATE_REQUEST|STATE_SNAPSHOT|WHISPER_CREATE|WHISPER_UPDATE|WHISPER_CLOSE|SPOTLIGHT_UPDATE|HANDOUT_STATE_REQUEST|HANDOUT_STATE_SNAPSHOT|HANDOUT_SPOTLIGHT_UPDATE|SPLIT_STATE_REQUEST|SPLIT_STATE_SNAPSHOT|SPLIT_START|SPLIT_END|SPLIT_ROOM_UPSERT|SPLIT_ROOM_REMOVE|SPLIT_ASSIGNMENT_SET|SPLIT_GM_FOCUS_UPDATE|SPLIT_GM_BROADCAST_UPDATE",
   "v": 1,
   "eventId": "uuid",
   "actor": "participant-identity",
@@ -23,9 +23,9 @@ The room session owns one shared DataChannel protocol boundary for all v1 event 
 - fans valid envelopes out by their discriminated `type` to feature handlers; and
 - reports publish outcomes as `ok`, `room-unavailable`, or `publish-failed`.
 
-Whisper and split-room handlers retain their domain responsibilities. Whisper handlers own whisper snapshots and reducer updates. Split-room handlers verify the trusted LiveKit sender identity and gamemaster authority before applying state.
+Whisper, handout, and split-room handlers retain their domain responsibilities. Whisper handlers own whisper snapshots and reducer updates. Handout and split-room handlers verify the trusted LiveKit sender identity and role attributes before applying authoritative state.
 
-When a participant joins, the whisper and split features each publish their typed state request. Existing eligible participants answer with feature-specific snapshots, so a late joiner hydrates through the same shared listener and routing boundary.
+When a participant joins, the whisper, handout, and split features each publish their typed state request. Existing eligible participants answer with feature-specific snapshots, so a late joiner hydrates through the same shared listener and routing boundary.
 
 ## Whisper payload
 
@@ -64,6 +64,28 @@ Both `SPLIT_STATE_SNAPSHOT` and `SPLIT_START` use the same `{ "splitState": ... 
 }
 ```
 
+## Handout spotlight payload
+
+`HANDOUT_SPOTLIGHT_UPDATE` starts, updates, or stops the shared scene. `HANDOUT_STATE_SNAPSHOT` uses the same payload for late joiners. A `null` handout is an authoritative stop tombstone.
+
+```json
+{
+  "handout": {
+    "imageUrl": "https://assets.example.com/ruined-observatory.jpg",
+    "title": "The ruined observatory",
+    "presenterIdentity": "gm",
+    "presenterRole": "gamemaster",
+    "updatedAt": 1730408755000
+  },
+  "updatedAt": 1730408755000
+}
+```
+
+- `imageUrl` must be an absolute `http://` or `https://` URL and is limited to 2,048 characters.
+- `title` is optional and limited to 80 characters.
+- `presenterRole` is `gamemaster` or `admin` and must match the sender's trusted LiveKit role attributes for direct updates.
+- Clients may minimize the presentation locally; this does not emit a protocol event or change authoritative room state.
+
 ## Conflict resolution
 
 1. Ignore duplicate `eventId`.
@@ -75,3 +97,10 @@ Both `SPLIT_STATE_SNAPSHOT` and `SPLIT_START` use the same `{ "splitState": ... 
 
 - `SPLIT_START` and `SPLIT_STATE_SNAPSHOT` are only accepted from a sender whose trusted LiveKit participant attributes report `game_role=gamemaster`.
 - Once split mode is active, subsequent split mutations are only accepted from the active `gmIdentity`.
+
+## Handout authority
+
+- The backend places lowercase `game_role` and `platform_role` values in signed LiveKit participant attributes.
+- `HANDOUT_SPOTLIGHT_UPDATE` and `HANDOUT_STATE_SNAPSHOT` are accepted only from senders with `game_role=gamemaster` or `platform_role=admin`.
+- Direct updates with an active handout must name the trusted sender as `presenterIdentity` and use the corresponding presenter role.
+- Only authorized participants answer `HANDOUT_STATE_REQUEST`; stop snapshots remain valid so stale images cannot reappear.

--- a/docs/plans/2026-07-09_handout-spotlight.md
+++ b/docs/plans/2026-07-09_handout-spotlight.md
@@ -1,0 +1,8 @@
+# Handout spotlight implementation plan
+
+1. Extend LiveKit token claims with trusted `game_role` and `platform_role` participant attributes.
+2. Add typed handout request, snapshot, and update protocol events with strict runtime validation and contract documentation.
+3. Add a handout state reducer/store and authority rules that accept updates only from authenticated gamemaster or admin participants.
+4. Add a room-session handout hook for broadcast, update, stop, late-join synchronization, and local minimize state.
+5. Add cohesive view-model/action contracts, an authorized sidebar control panel, and a cinematic stage presentation surface.
+6. Cover parsing, reducer ordering, authority enforcement, backend claims, and three-client broadcast/update/minimize/late-join/stop behavior.

--- a/frontend/e2e/handout-spotlight.spec.ts
+++ b/frontend/e2e/handout-spotlight.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "@playwright/test";
+import type { Browser, BrowserContext, Page, Route } from "@playwright/test";
+
+const TEST_ROOM = process.env.E2E_ROOM ?? "dnd-table-1";
+const E2E_EMAIL_DOMAIN = process.env.E2E_EMAIL_DOMAIN ?? "example.com";
+const FIRST_IMAGE_URL = "https://assets.example.test/observatory.svg";
+const UPDATED_IMAGE_URL = "https://assets.example.test/star-chart.svg";
+
+function devLoginUrl(room: string, displayName: string): string {
+  const next = `/room/${encodeURIComponent(room)}?name=${encodeURIComponent(displayName)}`;
+  const emailLocalPart = displayName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ".")
+    .replace(/^\.+|\.+$/g, "");
+  const params = new URLSearchParams({
+    email: `${emailLocalPart || "player"}@${E2E_EMAIL_DOMAIN}`,
+    name: displayName,
+    next
+  });
+  return `/api/v1/auth/dev-login?${params.toString()}`;
+}
+
+type ParticipantClient = {
+  context: BrowserContext;
+  page: Page;
+};
+
+async function fulfillHandoutImage(route: Route): Promise<void> {
+  const isUpdated = route.request().url().includes("star-chart");
+  await route.fulfill({
+    contentType: "image/svg+xml",
+    body: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450"><rect width="800" height="450" fill="${isUpdated ? "#101b2d" : "#24150e"}"/><circle cx="400" cy="225" r="120" fill="none" stroke="#c9963e" stroke-width="8"/><text x="400" y="235" text-anchor="middle" fill="#e8d5b4" font-size="42">${isUpdated ? "STAR CHART" : "OBSERVATORY"}</text></svg>`
+  });
+}
+
+async function openParticipant(browser: Browser, displayName: string): Promise<ParticipantClient> {
+  const context = await browser.newContext();
+  await context.route("https://assets.example.test/**", fulfillHandoutImage);
+  const page = await context.newPage();
+  await page.goto(devLoginUrl(TEST_ROOM, displayName));
+  await expect(page.getByRole("heading", { name: `Room: ${TEST_ROOM}` })).toBeVisible();
+  return { context, page };
+}
+
+async function expectHandout(page: Page, title: string, imageUrl: string): Promise<void> {
+  const spotlight = page.getByTestId("handout-spotlight");
+  await expect(spotlight).toBeVisible();
+  await expect(spotlight.getByRole("heading", { name: title })).toBeVisible();
+  await expect(page.getByTestId("handout-image")).toHaveAttribute("src", imageUrl);
+  await expect(page.getByTestId("handout-image")).toBeVisible();
+}
+
+test("GM broadcasts, updates, and stops a handout across three clients with late-join sync", async ({ browser }) => {
+  const gm = await openParticipant(browser, "GM");
+  const alice = await openParticipant(browser, "Alice");
+  let bob: ParticipantClient | undefined;
+
+  try {
+    await expect(gm.page.getByTestId("handout-control-panel")).toBeVisible();
+    await expect(alice.page.getByTestId("handout-control-panel")).toHaveCount(0);
+
+    await gm.page.getByLabel("Handout image URL").fill(FIRST_IMAGE_URL);
+    await gm.page.getByLabel("Handout caption").fill("The ruined observatory");
+    await gm.page.getByRole("button", { name: "Broadcast handout" }).click();
+
+    await Promise.all([
+      expectHandout(gm.page, "The ruined observatory", FIRST_IMAGE_URL),
+      expectHandout(alice.page, "The ruined observatory", FIRST_IMAGE_URL)
+    ]);
+    await expect(alice.page.getByText("ADMIN PRESENTATION")).toBeVisible();
+
+    await alice.page.getByRole("button", { name: "Minimize locally" }).click();
+    await expect(alice.page.getByTestId("handout-spotlight-minimized")).toBeVisible();
+    await expect(gm.page.getByTestId("handout-spotlight")).toBeVisible();
+
+    await gm.page.getByLabel("Handout image URL").fill(UPDATED_IMAGE_URL);
+    await gm.page.getByLabel("Handout caption").fill("The celestial lock");
+    await gm.page.getByRole("button", { name: "Update handout" }).click();
+
+    await expectHandout(gm.page, "The celestial lock", UPDATED_IMAGE_URL);
+    await expect(alice.page.getByTestId("handout-spotlight-minimized")).toContainText("The celestial lock");
+
+    bob = await openParticipant(browser, "Bob");
+    await expect(bob.page.getByTestId("handout-control-panel")).toHaveCount(0);
+    await expectHandout(bob.page, "The celestial lock", UPDATED_IMAGE_URL);
+
+    await alice.page.getByTestId("handout-spotlight-minimized").click();
+    await expectHandout(alice.page, "The celestial lock", UPDATED_IMAGE_URL);
+
+    await gm.page.getByRole("button", { name: "End spotlight" }).click();
+    await Promise.all(
+      [gm.page, alice.page, bob.page].map(async (page) => {
+        await expect(page.getByTestId("handout-spotlight")).toHaveCount(0);
+        await expect(page.getByTestId("handout-spotlight-minimized")).toHaveCount(0);
+      })
+    );
+  } finally {
+    await Promise.all([gm.context.close(), alice.context.close(), bob?.context.close()]);
+  }
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -3,6 +3,7 @@
 import { defineConfig, type ReporterDescription } from "@playwright/test";
 
 const baseURL = process.env.E2E_BASE_URL ?? "http://127.0.0.1:3100";
+const webServerPort = new URL(baseURL).port || (baseURL.startsWith("https:") ? "443" : "80");
 const ciReporter: ReporterDescription[] = [
   ["github"],
   ["junit", { outputFile: "test-results/junit.xml" }],
@@ -31,7 +32,7 @@ export default defineConfig({
     }
   },
   webServer: {
-    command: "pnpm exec vite dev --host 127.0.0.1 --port 3100",
+    command: `pnpm exec vite dev --host 127.0.0.1 --port ${webServerPort}`,
     url: baseURL,
     reuseExistingServer: false,
     stdout: "pipe",

--- a/frontend/src/features/room-session/components/HandoutControlPanel.tsx
+++ b/frontend/src/features/room-session/components/HandoutControlPanel.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { MAX_HANDOUT_TITLE_LENGTH, MAX_HANDOUT_URL_LENGTH } from "@/lib/protocol";
+import type {
+  HandoutControlPanelActions,
+  HandoutControlPanelViewModel
+} from "@/features/room-session/types";
+
+type HandoutControlPanelProps = {
+  model: HandoutControlPanelViewModel;
+  actions: HandoutControlPanelActions;
+};
+
+export function HandoutControlPanel({
+  model: { handout, isPublishing, commandError },
+  actions: { onBroadcast, onStop }
+}: HandoutControlPanelProps) {
+  const [imageUrl, setImageUrl] = useState("");
+  const [title, setTitle] = useState("");
+
+  useEffect(() => {
+    if (handout) {
+      setImageUrl(handout.imageUrl);
+      setTitle(handout.title ?? "");
+    }
+  }, [handout]);
+
+  return (
+    <section className="px-5 pt-5 pb-4" data-testid="handout-control-panel">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-[9px] font-semibold tracking-[0.2em] text-[var(--c-gold)]">PRESENTATION DESK</p>
+          <h3 className="display-face mt-1 text-xs text-[var(--c-text-warm)]">Scene spotlight</h3>
+        </div>
+        {handout ? (
+          <span className="mt-0.5 inline-flex items-center gap-1.5 text-[9px] font-semibold tracking-[0.12em] text-[var(--c-emerald)]">
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[var(--c-emerald)]" /> LIVE
+          </span>
+        ) : null}
+      </div>
+
+      <form
+        className="mt-4 space-y-3"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void onBroadcast(imageUrl, title);
+        }}
+      >
+        <label className="block">
+          <span className="text-[10px] uppercase tracking-[0.08em] text-[var(--c-text-faint)]">Image URL</span>
+          <input
+            aria-label="Handout image URL"
+            className="field mt-1 text-xs"
+            disabled={isPublishing}
+            maxLength={MAX_HANDOUT_URL_LENGTH}
+            onChange={(event) => setImageUrl(event.target.value)}
+            placeholder="https://…/scene.jpg"
+            type="url"
+            value={imageUrl}
+          />
+        </label>
+        <label className="block">
+          <span className="text-[10px] uppercase tracking-[0.08em] text-[var(--c-text-faint)]">Caption</span>
+          <input
+            aria-label="Handout caption"
+            className="field mt-1 text-xs"
+            disabled={isPublishing}
+            maxLength={MAX_HANDOUT_TITLE_LENGTH}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="The ruined observatory"
+            value={title}
+          />
+        </label>
+
+        {commandError ? (
+          <p className="text-[11px] leading-4 text-[var(--c-ember)]" role="alert">
+            {commandError}
+          </p>
+        ) : null}
+
+        <div className="flex items-center justify-between gap-3 pt-1">
+          <button className="chip" disabled={isPublishing} type="submit">
+            {isPublishing ? "Sending…" : handout ? "Update handout" : "Broadcast handout"}
+          </button>
+          {handout ? (
+            <button
+              className="act act--hot"
+              disabled={isPublishing}
+              onClick={() => void onStop()}
+              type="button"
+            >
+              End spotlight
+            </button>
+          ) : null}
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/frontend/src/features/room-session/components/HandoutSpotlightSurface.tsx
+++ b/frontend/src/features/room-session/components/HandoutSpotlightSurface.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from "react";
+import type {
+  HandoutSpotlightActions,
+  HandoutSpotlightViewModel
+} from "@/features/room-session/types";
+
+type HandoutSpotlightSurfaceProps = {
+  model: HandoutSpotlightViewModel;
+  actions: HandoutSpotlightActions;
+};
+
+export function HandoutSpotlightSurface({
+  model: { handout, presenterLabel, isMinimized },
+  actions: { onMinimize, onRestore }
+}: HandoutSpotlightSurfaceProps) {
+  const [imageFailed, setImageFailed] = useState(false);
+
+  useEffect(() => setImageFailed(false), [handout?.imageUrl]);
+
+  if (!handout) {
+    return null;
+  }
+
+  if (isMinimized) {
+    return (
+      <button
+        className="absolute bottom-5 left-5 z-20 flex max-w-[min(24rem,calc(100%-2.5rem))] items-center gap-3 border border-[var(--c-gold)]/40 bg-[var(--c-ink)]/95 px-4 py-3 text-left shadow-2xl backdrop-blur-md transition hover:border-[var(--c-gold)]"
+        data-testid="handout-spotlight-minimized"
+        onClick={onRestore}
+        type="button"
+      >
+        <span className="h-2 w-2 shrink-0 animate-pulse rounded-full bg-[var(--c-gold)]" />
+        <span className="min-w-0">
+          <span className="block text-[9px] font-semibold tracking-[0.18em] text-[var(--c-gold)]">HANDOUT LIVE</span>
+          <span className="display-face block truncate text-xs text-[var(--c-text-warm)]">
+            {handout.title ?? "Untitled scene"}
+          </span>
+        </span>
+        <span className="ml-auto shrink-0 text-[9px] uppercase tracking-[0.1em] text-[var(--c-text-dim)]">Restore</span>
+      </button>
+    );
+  }
+
+  return (
+    <article
+      aria-label="Shared handout spotlight"
+      className="absolute inset-0 z-10 flex flex-col overflow-hidden bg-[color-mix(in_srgb,var(--c-void)_92%,black)]"
+      data-testid="handout-spotlight"
+    >
+      <div className="pointer-events-none absolute inset-0 opacity-60 [background:radial-gradient(circle_at_50%_40%,rgba(201,150,62,0.12),transparent_52%)]" />
+      <header className="relative flex shrink-0 items-center justify-between gap-5 border-b border-[var(--c-rule-strong)] px-6 py-3">
+        <div className="min-w-0">
+          <p className="text-[9px] font-semibold tracking-[0.22em] text-[var(--c-gold)]">
+            {handout.presenterRole === "admin" ? "ADMIN PRESENTATION" : "GAMEMASTER PRESENTATION"}
+          </p>
+          <h2 className="display-face mt-1 truncate text-base text-[var(--c-text-warm)]">
+            {handout.title ?? "Untitled scene"}
+          </h2>
+        </div>
+        <div className="flex shrink-0 items-center gap-4">
+          <p className="hidden text-right text-[10px] leading-4 text-[var(--c-text-faint)] sm:block">
+            Presented by
+            <span className="block text-[var(--c-text-dim)]" data-testid="handout-presenter">
+              {presenterLabel}
+            </span>
+          </p>
+          <button className="act" onClick={onMinimize} type="button">
+            Minimize locally
+          </button>
+        </div>
+      </header>
+
+      <div className="relative flex min-h-0 flex-1 items-center justify-center p-5 sm:p-8">
+        <div className="relative flex h-full w-full items-center justify-center overflow-hidden border border-[var(--c-rule-strong)] bg-black/40 p-2 shadow-[0_24px_80px_rgba(0,0,0,0.6)] sm:p-4">
+          <span className="pointer-events-none absolute top-0 left-0 h-8 w-8 border-t border-l border-[var(--c-gold)]/55" />
+          <span className="pointer-events-none absolute right-0 bottom-0 h-8 w-8 border-r border-b border-[var(--c-gold)]/55" />
+          {imageFailed ? (
+            <div className="max-w-sm text-center">
+              <p className="display-face text-lg text-[var(--c-text-warm)]">The image could not be displayed</p>
+              <p className="mt-2 text-xs leading-5 text-[var(--c-text-dim)]">
+                The spotlight is still active. Open the source directly or ask the presenter to update it.
+              </p>
+              <a
+                className="act act--gold mt-5"
+                href={handout.imageUrl}
+                rel="noreferrer"
+                target="_blank"
+              >
+                Open source image
+              </a>
+            </div>
+          ) : (
+            <img
+              alt={handout.title ?? "Shared handout"}
+              className="block max-h-full max-w-full object-contain"
+              data-testid="handout-image"
+              onError={() => setImageFailed(true)}
+              src={handout.imageUrl}
+            />
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/features/room-session/components/RoomSessionController.tsx
+++ b/frontend/src/features/room-session/components/RoomSessionController.tsx
@@ -2,15 +2,16 @@
 
 import { DevicePanel } from "@/features/room-session/components/DevicePanel";
 import { DiagnosticsPanel } from "@/features/room-session/components/DiagnosticsPanel";
+import { HandoutControlPanel } from "@/features/room-session/components/HandoutControlPanel";
 import { ParticipantRoster } from "@/features/room-session/components/ParticipantRoster";
 import { RemoteAudioLayer } from "@/features/room-session/components/RemoteAudioLayer";
 import { RoomSessionLayout } from "@/features/room-session/components/RoomSessionLayout";
 import { RoomSessionState } from "@/features/room-session/components/RoomSessionState";
+import { RoomStage } from "@/features/room-session/components/RoomStage";
 import { RoomTopBar } from "@/features/room-session/components/RoomTopBar";
 import { SessionSidebar } from "@/features/room-session/components/SessionSidebar";
 import { SplitControlPanel } from "@/features/room-session/components/SplitControlPanel";
 import { SplitStatusPanel } from "@/features/room-session/components/SplitStatusPanel";
-import { VideoGrid } from "@/features/room-session/components/VideoGrid";
 import { WhisperPanel } from "@/features/room-session/components/WhisperPanel";
 import { useRoomSessionViewModel } from "@/features/room-session/hooks/useRoomSessionViewModel";
 
@@ -45,10 +46,20 @@ export function RoomSessionController({ roomName, displayName }: RoomSessionCont
     <>
       <RoomSessionLayout
         header={<RoomTopBar {...viewModel.topBar} />}
-        main={<VideoGrid {...viewModel.videoGrid} />}
+        main={
+          <RoomStage
+            videoGrid={viewModel.videoGrid}
+            handoutSpotlight={viewModel.handoutSpotlight}
+          />
+        }
         sidebar={
           <SessionSidebar
             open={viewModel.sidebar.open}
+            handoutPanel={
+              viewModel.sidebar.handoutControl ? (
+                <HandoutControlPanel {...viewModel.sidebar.handoutControl} />
+              ) : undefined
+            }
             splitPanel={splitPanel}
             whisperPanel={<WhisperPanel {...viewModel.sidebar.whisperPanel} />}
             rosterPanel={

--- a/frontend/src/features/room-session/components/RoomStage.tsx
+++ b/frontend/src/features/room-session/components/RoomStage.tsx
@@ -1,0 +1,22 @@
+import { HandoutSpotlightSurface } from "@/features/room-session/components/HandoutSpotlightSurface";
+import { VideoGrid } from "@/features/room-session/components/VideoGrid";
+import type {
+  HandoutSpotlightActions,
+  HandoutSpotlightViewModel,
+  VideoGridActions,
+  VideoGridViewModel
+} from "@/features/room-session/types";
+
+type RoomStageProps = {
+  videoGrid: { model: VideoGridViewModel; actions: VideoGridActions };
+  handoutSpotlight: { model: HandoutSpotlightViewModel; actions: HandoutSpotlightActions };
+};
+
+export function RoomStage({ videoGrid, handoutSpotlight }: RoomStageProps) {
+  return (
+    <div className="relative flex min-w-0 flex-1 overflow-hidden">
+      <VideoGrid {...videoGrid} />
+      <HandoutSpotlightSurface {...handoutSpotlight} />
+    </div>
+  );
+}

--- a/frontend/src/features/room-session/components/SessionSidebar.tsx
+++ b/frontend/src/features/room-session/components/SessionSidebar.tsx
@@ -2,13 +2,14 @@ import type { ReactNode } from "react";
 
 type SessionSidebarProps = {
   open: boolean;
+  handoutPanel?: ReactNode;
   splitPanel?: ReactNode;
   whisperPanel: ReactNode;
   rosterPanel: ReactNode;
   devicePanel: ReactNode;
 };
 
-export function SessionSidebar({ open, splitPanel, whisperPanel, rosterPanel, devicePanel }: SessionSidebarProps) {
+export function SessionSidebar({ open, handoutPanel, splitPanel, whisperPanel, rosterPanel, devicePanel }: SessionSidebarProps) {
   return (
     <aside
       className={`z-10 flex shrink-0 flex-col bg-[var(--c-ink)] transition-[width] duration-300 ${
@@ -16,6 +17,8 @@ export function SessionSidebar({ open, splitPanel, whisperPanel, rosterPanel, de
       }`}
     >
       <div className="sidebar-scroll flex flex-1 flex-col overflow-y-auto">
+        {handoutPanel}
+        {handoutPanel ? <div className="mx-5 h-px bg-[var(--c-rule)]" /> : null}
         {splitPanel}
         {splitPanel ? <div className="mx-5 h-px bg-[var(--c-rule)]" /> : null}
         {whisperPanel}

--- a/frontend/src/features/room-session/hooks/useHandoutSpotlightSession.ts
+++ b/frontend/src/features/room-session/hooks/useHandoutSpotlightSession.ts
@@ -1,0 +1,208 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { Room } from "livekit-client";
+import type {
+  AnyProtocolEnvelope,
+  HandoutSpotlightStatePayload
+} from "@/lib/protocol";
+import { createEnvelope } from "@/lib/protocol";
+import type {
+  RoomProtocol,
+  RoomProtocolMessageContext
+} from "@/features/room-session/lib/room-protocol";
+import {
+  canManageHandoutSpotlight,
+  normalizeHandoutImageUrl,
+  normalizeHandoutTitle,
+  resolveHandoutPresenterRole,
+  resolveParticipantAuthorityRoles,
+  shouldAcceptHandoutEnvelopeFromSender
+} from "@/features/room-session/lib/handout-spotlight-rules";
+import { useHandoutSpotlightStore } from "@/features/room-session/store/handoutSpotlightStore";
+import type { CommandResult, GameRole, PlatformRole } from "@/features/room-session/types";
+
+type UseHandoutSpotlightSessionInput = {
+  room: Room | null;
+  protocol: RoomProtocol;
+  identity: string;
+  gameRole?: GameRole;
+  platformRole?: PlatformRole;
+};
+
+export function useHandoutSpotlightSession({
+  room,
+  protocol,
+  identity,
+  gameRole,
+  platformRole
+}: UseHandoutSpotlightSessionInput) {
+  const handout = useHandoutSpotlightStore((state) => state.handout);
+  const updatedAt = useHandoutSpotlightStore((state) => state.updatedAt);
+  const applyEnvelope = useHandoutSpotlightStore((state) => state.applyEnvelope);
+  const reset = useHandoutSpotlightStore((state) => state.reset);
+  const [isMinimized, setIsMinimized] = useState(false);
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [commandError, setCommandError] = useState<string | null>(null);
+
+  const canManage = canManageHandoutSpotlight({ gameRole, platformRole });
+  const presenterRole = resolveHandoutPresenterRole({ gameRole, platformRole });
+
+  const publishEnvelope = useCallback(
+    async (envelope: AnyProtocolEnvelope, applyLocally = true) => {
+      const result = await protocol.publish(envelope);
+      if (!result.ok) {
+        return false;
+      }
+      if (applyLocally) {
+        applyEnvelope(envelope);
+      }
+      return true;
+    },
+    [applyEnvelope, protocol]
+  );
+
+  useEffect(() => () => reset(), [reset]);
+
+  useEffect(() => {
+    setCommandError(null);
+    setIsMinimized(false);
+    if (!room || !identity) {
+      reset();
+    }
+  }, [identity, reset, room]);
+
+  useEffect(() => {
+    if (!handout) {
+      setIsMinimized(false);
+    }
+  }, [handout]);
+
+  useEffect(() => {
+    if (!room || !identity) {
+      return;
+    }
+
+    const onStateRequest = (
+      envelope: Extract<AnyProtocolEnvelope, { type: "HANDOUT_STATE_REQUEST" }>,
+      { senderIdentity }: RoomProtocolMessageContext
+    ) => {
+      if (envelope.actor !== senderIdentity || !canManage) {
+        return;
+      }
+
+      const currentState = useHandoutSpotlightStore.getState();
+      if (currentState.updatedAt === 0) {
+        return;
+      }
+      const snapshot = createEnvelope("HANDOUT_STATE_SNAPSHOT", identity, {
+        handout: currentState.handout ?? null,
+        updatedAt: currentState.updatedAt
+      });
+      void publishEnvelope(snapshot, false);
+    };
+
+    const onStateEnvelope = (
+      envelope: Extract<
+        AnyProtocolEnvelope,
+        { type: "HANDOUT_STATE_SNAPSHOT" | "HANDOUT_SPOTLIGHT_UPDATE" }
+      >,
+      { participant, senderIdentity }: RoomProtocolMessageContext
+    ) => {
+      if (!participant || envelope.actor !== senderIdentity || participant.identity !== senderIdentity) {
+        return;
+      }
+
+      const roles = resolveParticipantAuthorityRoles(participant.attributes);
+      if (!shouldAcceptHandoutEnvelopeFromSender({ envelope, senderIdentity, ...roles })) {
+        return;
+      }
+      applyEnvelope(envelope);
+    };
+
+    const unsubscribers = [
+      protocol.subscribe("HANDOUT_STATE_REQUEST", onStateRequest),
+      protocol.subscribe("HANDOUT_STATE_SNAPSHOT", onStateEnvelope),
+      protocol.subscribe("HANDOUT_SPOTLIGHT_UPDATE", onStateEnvelope)
+    ];
+    void publishEnvelope(createEnvelope("HANDOUT_STATE_REQUEST", identity, {}), false);
+
+    return () => {
+      unsubscribers.forEach((unsubscribe) => unsubscribe());
+    };
+  }, [applyEnvelope, canManage, identity, protocol, publishEnvelope, room]);
+
+  const publishState = useCallback(
+    async (payload: HandoutSpotlightStatePayload, failureMessage: string): Promise<CommandResult> => {
+      setCommandError(null);
+      setIsPublishing(true);
+      try {
+        const didPublish = await publishEnvelope(
+          createEnvelope("HANDOUT_SPOTLIGHT_UPDATE", identity, payload)
+        );
+        if (!didPublish) {
+          setCommandError(failureMessage);
+        }
+        return didPublish ? { ok: true } : { ok: false };
+      } finally {
+        setIsPublishing(false);
+      }
+    },
+    [identity, publishEnvelope]
+  );
+
+  const broadcastHandout = useCallback(
+    async (imageUrlInput: string, titleInput: string): Promise<CommandResult> => {
+      if (!canManage || !presenterRole || !identity) {
+        setCommandError("Only a gamemaster or platform admin can present a handout.");
+        return { ok: false };
+      }
+
+      const imageUrl = normalizeHandoutImageUrl(imageUrlInput);
+      if (!imageUrl) {
+        setCommandError("Enter a complete http:// or https:// image URL.");
+        return { ok: false };
+      }
+      const nextUpdatedAt = Math.max(Date.now(), useHandoutSpotlightStore.getState().updatedAt + 1);
+      return publishState(
+        {
+          handout: {
+            imageUrl,
+            title: normalizeHandoutTitle(titleInput),
+            presenterIdentity: identity,
+            presenterRole,
+            updatedAt: nextUpdatedAt
+          },
+          updatedAt: nextUpdatedAt
+        },
+        "The handout could not be broadcast while disconnected."
+      );
+    },
+    [canManage, identity, presenterRole, publishState]
+  );
+
+  const stopHandout = useCallback(async (): Promise<CommandResult> => {
+    if (!canManage || !identity) {
+      setCommandError("Only a gamemaster or platform admin can stop a handout.");
+      return { ok: false };
+    }
+    const nextUpdatedAt = Math.max(Date.now(), useHandoutSpotlightStore.getState().updatedAt + 1);
+    return publishState(
+      { handout: null, updatedAt: nextUpdatedAt },
+      "The handout could not be stopped while disconnected."
+    );
+  }, [canManage, identity, publishState]);
+
+  return {
+    handout,
+    updatedAt,
+    canManage,
+    isMinimized,
+    isPublishing,
+    commandError,
+    broadcastHandout,
+    stopHandout,
+    minimize: () => setIsMinimized(true),
+    restore: () => setIsMinimized(false)
+  };
+}

--- a/frontend/src/features/room-session/hooks/useRoomConnection.ts
+++ b/frontend/src/features/room-session/hooks/useRoomConnection.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { DisconnectReason, Room, RoomEvent } from "livekit-client";
-import type { GameRole } from "@/features/room-session/types";
+import type { GameRole, PlatformRole } from "@/features/room-session/types";
 import {
   areSetsEqual,
   formatConnectionError,
@@ -24,6 +24,7 @@ const DISCONNECT_MESSAGES: Partial<Record<DisconnectReason, string>> = {
 
 export function useRoomConnection({ roomName, displayName }: UseRoomConnectionInput) {
   const [gameRole, setGameRole] = useState<GameRole | undefined>(undefined);
+  const [platformRole, setPlatformRole] = useState<PlatformRole | undefined>(undefined);
   const [token, setToken] = useState("");
   const [identity, setIdentity] = useState("");
   const [room, setRoom] = useState<Room | null>(null);
@@ -37,6 +38,7 @@ export function useRoomConnection({ roomName, displayName }: UseRoomConnectionIn
   useEffect(() => {
     if (!displayName.trim()) {
       setGameRole(undefined);
+      setPlatformRole(undefined);
       setToken("");
       setIdentity("");
       setRoom(null);
@@ -48,6 +50,7 @@ export function useRoomConnection({ roomName, displayName }: UseRoomConnectionIn
 
     const controller = new AbortController();
     setGameRole(undefined);
+    setPlatformRole(undefined);
     setToken("");
     setIdentity("");
     setIsConnecting(true);
@@ -74,6 +77,7 @@ export function useRoomConnection({ roomName, displayName }: UseRoomConnectionIn
         }
 
         setGameRole(normalizeGameRole(body?.game_role));
+        setPlatformRole(normalizePlatformRole(body?.platform_role));
         setIdentity(body.identity ?? "");
         setToken(body.token);
       } catch (err) {
@@ -192,6 +196,7 @@ export function useRoomConnection({ roomName, displayName }: UseRoomConnectionIn
     disconnect: () => room?.disconnect(),
     error,
     gameRole,
+    platformRole,
     identity,
     isConnecting,
     renderVersion,
@@ -200,5 +205,17 @@ export function useRoomConnection({ roomName, displayName }: UseRoomConnectionIn
 }
 
 function normalizeGameRole(value: unknown): GameRole | undefined {
-  return value === "gamemaster" || value === "player" ? value : undefined;
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.toLowerCase();
+  return normalized === "gamemaster" || normalized === "player" ? normalized : undefined;
+}
+
+function normalizePlatformRole(value: unknown): PlatformRole | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.toLowerCase();
+  return normalized === "admin" || normalized === "user" ? normalized : undefined;
 }

--- a/frontend/src/features/room-session/hooks/useRoomSessionViewModel.ts
+++ b/frontend/src/features/room-session/hooks/useRoomSessionViewModel.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { useRoomConnection } from "@/features/room-session/hooks/useRoomConnection";
 import { useRoomDiagnostics } from "@/features/room-session/hooks/useRoomDiagnostics";
+import { useHandoutSpotlightSession } from "@/features/room-session/hooks/useHandoutSpotlightSession";
 import { useRoomMedia } from "@/features/room-session/hooks/useRoomMedia";
 import { useRoomParticipants } from "@/features/room-session/hooks/useRoomParticipants";
 import { useRoomProtocol } from "@/features/room-session/hooks/useRoomProtocol";
@@ -9,12 +10,17 @@ import { useWhisperSession } from "@/features/room-session/hooks/useWhisperSessi
 import {
   buildAudioTracks,
   buildRoomSessionCollections,
-  buildVideoTiles
+  buildVideoTiles,
+  resolveParticipantLabel
 } from "@/features/room-session/lib/session-selectors";
 import type {
   CommandResult,
   DevicePanelActions,
   DevicePanelViewModel,
+  HandoutControlPanelActions,
+  HandoutControlPanelViewModel,
+  HandoutSpotlightActions,
+  HandoutSpotlightViewModel,
   RoomTopBarActions,
   RoomTopBarViewModel,
   SplitControlPanelActions,
@@ -65,6 +71,13 @@ export function useRoomSessionViewModel({ roomName, displayName }: UseRoomSessio
     identity: connection.identity,
     gameRole: connection.gameRole,
     participantIdentities
+  });
+  const handoutSession = useHandoutSpotlightSession({
+    room: connection.room,
+    protocol,
+    identity: connection.identity,
+    gameRole: connection.gameRole,
+    platformRole: connection.platformRole
   });
   const whisperSession = useWhisperSession({
     room: connection.room,
@@ -257,6 +270,34 @@ export function useRoomSessionViewModel({ roomName, displayName }: UseRoomSessio
     } satisfies DevicePanelActions
   };
 
+  const handoutControl = handoutSession.canManage
+    ? {
+        model: {
+          handout: handoutSession.handout,
+          isPublishing: handoutSession.isPublishing,
+          commandError: handoutSession.commandError
+        } satisfies HandoutControlPanelViewModel,
+        actions: {
+          onBroadcast: handoutSession.broadcastHandout,
+          onStop: handoutSession.stopHandout
+        } satisfies HandoutControlPanelActions
+      }
+    : undefined;
+
+  const handoutSpotlight = {
+    model: {
+      handout: handoutSession.handout,
+      presenterLabel: handoutSession.handout
+        ? resolveParticipantLabel(handoutSession.handout.presenterIdentity, participantDisplayNames)
+        : "",
+      isMinimized: handoutSession.isMinimized
+    } satisfies HandoutSpotlightViewModel,
+    actions: {
+      onMinimize: handoutSession.minimize,
+      onRestore: handoutSession.restore
+    } satisfies HandoutSpotlightActions
+  };
+
   return {
     status: {
       isConnecting: connection.isConnecting || media.isInitializing,
@@ -265,8 +306,10 @@ export function useRoomSessionViewModel({ roomName, displayName }: UseRoomSessio
     },
     topBar,
     videoGrid,
+    handoutSpotlight,
     sidebar: {
       open: sidebarOpen,
+      handoutControl,
       splitPanelVisible: splitSession.canManageSplitRooms || splitSession.isActive || Boolean(splitSession.notice),
       splitControl,
       splitStatus: {

--- a/frontend/src/features/room-session/lib/handout-spotlight-rules.test.ts
+++ b/frontend/src/features/room-session/lib/handout-spotlight-rules.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { createEnvelope } from "@/lib/protocol";
+import {
+  canManageHandoutSpotlight,
+  normalizeHandoutImageUrl,
+  normalizeHandoutTitle,
+  resolveHandoutPresenterRole,
+  resolveParticipantAuthorityRoles,
+  shouldAcceptHandoutEnvelopeFromSender
+} from "@/features/room-session/lib/handout-spotlight-rules";
+
+describe("handout spotlight authority", () => {
+  it("allows gamemasters and admins but not ordinary players", () => {
+    expect(canManageHandoutSpotlight({ gameRole: "gamemaster", platformRole: "user" })).toBe(true);
+    expect(canManageHandoutSpotlight({ gameRole: "player", platformRole: "admin" })).toBe(true);
+    expect(canManageHandoutSpotlight({ gameRole: "player", platformRole: "user" })).toBe(false);
+    expect(resolveHandoutPresenterRole({ gameRole: "gamemaster", platformRole: "admin" })).toBe("admin");
+  });
+
+  it("resolves only trusted role attributes", () => {
+    expect(resolveParticipantAuthorityRoles({ game_role: "gamemaster", platform_role: "user" })).toEqual({
+      gameRole: "gamemaster",
+      platformRole: "user"
+    });
+    expect(resolveParticipantAuthorityRoles({ game_role: "owner", platform_role: "superuser" })).toEqual({
+      gameRole: undefined,
+      platformRole: undefined
+    });
+  });
+
+  it("rejects player updates and presenter claims that do not match the sender", () => {
+    const update = createEnvelope("HANDOUT_SPOTLIGHT_UPDATE", "gm", {
+      handout: {
+        imageUrl: "https://example.com/scene.jpg",
+        presenterIdentity: "gm",
+        presenterRole: "gamemaster",
+        updatedAt: 10
+      },
+      updatedAt: 10
+    });
+
+    expect(
+      shouldAcceptHandoutEnvelopeFromSender({
+        envelope: update,
+        senderIdentity: "gm",
+        gameRole: "player",
+        platformRole: "user"
+      })
+    ).toBe(false);
+    expect(
+      shouldAcceptHandoutEnvelopeFromSender({
+        envelope: update,
+        senderIdentity: "someone-else",
+        gameRole: "gamemaster",
+        platformRole: "user"
+      })
+    ).toBe(false);
+    expect(
+      shouldAcceptHandoutEnvelopeFromSender({
+        envelope: update,
+        senderIdentity: "gm",
+        gameRole: "gamemaster",
+        platformRole: "user"
+      })
+    ).toBe(true);
+  });
+
+  it("accepts snapshots from any authorized participant", () => {
+    const snapshot = createEnvelope("HANDOUT_STATE_SNAPSHOT", "admin", {
+      handout: {
+        imageUrl: "https://example.com/scene.jpg",
+        presenterIdentity: "gm",
+        presenterRole: "gamemaster",
+        updatedAt: 10
+      },
+      updatedAt: 10
+    });
+
+    expect(
+      shouldAcceptHandoutEnvelopeFromSender({
+        envelope: snapshot,
+        senderIdentity: "admin",
+        gameRole: "player",
+        platformRole: "admin"
+      })
+    ).toBe(true);
+  });
+});
+
+describe("handout spotlight input normalization", () => {
+  it("accepts web image URLs and rejects unsafe or relative URLs", () => {
+    expect(normalizeHandoutImageUrl(" https://example.com/map one.jpg ")).toBe(
+      "https://example.com/map%20one.jpg"
+    );
+    expect(normalizeHandoutImageUrl("javascript:alert(1)")).toBeNull();
+    expect(normalizeHandoutImageUrl("/local-map.jpg")).toBeNull();
+  });
+
+  it("trims and caps optional titles", () => {
+    expect(normalizeHandoutTitle("  The Library  ")).toBe("The Library");
+    expect(normalizeHandoutTitle("   ")).toBeUndefined();
+    expect(normalizeHandoutTitle("x".repeat(100))).toHaveLength(80);
+  });
+});

--- a/frontend/src/features/room-session/lib/handout-spotlight-rules.ts
+++ b/frontend/src/features/room-session/lib/handout-spotlight-rules.ts
@@ -1,0 +1,91 @@
+import type {
+  AnyProtocolEnvelope,
+  HandoutPresenterRole
+} from "@/lib/protocol";
+import {
+  MAX_HANDOUT_TITLE_LENGTH,
+  MAX_HANDOUT_URL_LENGTH
+} from "@/lib/protocol";
+import type { GameRole, PlatformRole } from "@/features/room-session/types";
+
+type HandoutAuthorityInput = {
+  gameRole?: GameRole;
+  platformRole?: PlatformRole;
+};
+
+type HandoutEnvelope = Extract<
+  AnyProtocolEnvelope,
+  { type: "HANDOUT_STATE_REQUEST" | "HANDOUT_STATE_SNAPSHOT" | "HANDOUT_SPOTLIGHT_UPDATE" }
+>;
+
+type HandoutEnvelopeSenderInput = HandoutAuthorityInput & {
+  envelope: HandoutEnvelope;
+  senderIdentity: string;
+};
+
+export function canManageHandoutSpotlight({ gameRole, platformRole }: HandoutAuthorityInput): boolean {
+  return gameRole === "gamemaster" || platformRole === "admin";
+}
+
+export function resolveHandoutPresenterRole({
+  gameRole,
+  platformRole
+}: HandoutAuthorityInput): HandoutPresenterRole | undefined {
+  if (platformRole === "admin") {
+    return "admin";
+  }
+  return gameRole === "gamemaster" ? "gamemaster" : undefined;
+}
+
+export function resolveParticipantAuthorityRoles(
+  attributes?: Readonly<Record<string, string>> | null
+): HandoutAuthorityInput {
+  const gameRole = attributes?.game_role;
+  const platformRole = attributes?.platform_role;
+  return {
+    gameRole: gameRole === "gamemaster" || gameRole === "player" ? gameRole : undefined,
+    platformRole: platformRole === "admin" || platformRole === "user" ? platformRole : undefined
+  };
+}
+
+export function shouldAcceptHandoutEnvelopeFromSender({
+  envelope,
+  senderIdentity,
+  gameRole,
+  platformRole
+}: HandoutEnvelopeSenderInput): boolean {
+  if (envelope.type === "HANDOUT_STATE_REQUEST") {
+    return true;
+  }
+  if (!canManageHandoutSpotlight({ gameRole, platformRole })) {
+    return false;
+  }
+  if (envelope.type === "HANDOUT_STATE_SNAPSHOT" || envelope.payload.handout === null) {
+    return true;
+  }
+
+  const presenterRole = resolveHandoutPresenterRole({ gameRole, platformRole });
+  return (
+    envelope.payload.handout.presenterIdentity === senderIdentity &&
+    envelope.payload.handout.presenterRole === presenterRole
+  );
+}
+
+export function normalizeHandoutImageUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_HANDOUT_URL_LENGTH) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === "https:" || parsed.protocol === "http:" ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeHandoutTitle(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, MAX_HANDOUT_TITLE_LENGTH) : undefined;
+}

--- a/frontend/src/features/room-session/lib/room-protocol.test.ts
+++ b/frontend/src/features/room-session/lib/room-protocol.test.ts
@@ -9,14 +9,16 @@ import {
 import { createEnvelope } from "@/lib/protocol";
 
 describe("room protocol router", () => {
-  it("routes whisper and split envelopes only to their typed subscribers", () => {
+  it("routes whisper, handout, and split envelopes only to their typed subscribers", () => {
     const router = createRoomProtocolRouter();
     const whisperHandler = vi.fn();
     const whisperObserver = vi.fn();
     const splitHandler = vi.fn();
+    const handoutHandler = vi.fn();
     const unsubscribeWhisper = router.subscribe("WHISPER_CREATE", whisperHandler);
     router.subscribe("WHISPER_CREATE", whisperObserver);
     router.subscribe("SPLIT_STATE_SNAPSHOT", splitHandler);
+    router.subscribe("HANDOUT_SPOTLIGHT_UPDATE", handoutHandler);
 
     const whisperEnvelope = createEnvelope("WHISPER_CREATE", "alice", {
       id: "whisper-1",
@@ -37,8 +39,17 @@ describe("room protocol router", () => {
     });
     const gmParticipant = {
       identity: "gm",
-      attributes: { game_role: "gamemaster" }
+      attributes: { game_role: "gamemaster", platform_role: "user" }
     } as unknown as Participant;
+    const handoutEnvelope = createEnvelope("HANDOUT_SPOTLIGHT_UPDATE", "gm", {
+      handout: {
+        imageUrl: "https://example.com/scene.jpg",
+        presenterIdentity: "gm",
+        presenterRole: "gamemaster",
+        updatedAt: 30
+      },
+      updatedAt: 30
+    });
 
     expect(router.route(encodeRoomProtocolEnvelope(whisperEnvelope))).toBe(true);
     expect(whisperHandler).toHaveBeenCalledWith(
@@ -54,6 +65,13 @@ describe("room protocol router", () => {
       senderIdentity: "gm"
     });
     expect(whisperHandler).toHaveBeenCalledTimes(1);
+    expect(handoutHandler).not.toHaveBeenCalled();
+
+    expect(router.route(encodeRoomProtocolEnvelope(handoutEnvelope), gmParticipant)).toBe(true);
+    expect(handoutHandler).toHaveBeenCalledWith(handoutEnvelope, {
+      participant: gmParticipant,
+      senderIdentity: "gm"
+    });
 
     unsubscribeWhisper();
     router.route(encodeRoomProtocolEnvelope(whisperEnvelope));

--- a/frontend/src/features/room-session/store/handoutSpotlightStore.test.ts
+++ b/frontend/src/features/room-session/store/handoutSpotlightStore.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { createEnvelope } from "@/lib/protocol";
+import {
+  reduceHandoutSpotlightState,
+  type HandoutSpotlightCoreState
+} from "@/features/room-session/store/handoutSpotlightStore";
+
+const baseState: HandoutSpotlightCoreState = {
+  handout: undefined,
+  updatedAt: 0,
+  seenEventIds: {}
+};
+
+function handout(updatedAt: number, imageUrl = "https://example.com/scene.jpg") {
+  return {
+    imageUrl,
+    title: "The Observatory",
+    presenterIdentity: "gm",
+    presenterRole: "gamemaster" as const,
+    updatedAt
+  };
+}
+
+describe("handout spotlight store", () => {
+  it("applies start, update, and stop events", () => {
+    const started = reduceHandoutSpotlightState(
+      baseState,
+      createEnvelope("HANDOUT_SPOTLIGHT_UPDATE", "gm", {
+        handout: handout(10),
+        updatedAt: 10
+      })
+    );
+    const updated = reduceHandoutSpotlightState(
+      started,
+      createEnvelope("HANDOUT_SPOTLIGHT_UPDATE", "gm", {
+        handout: handout(20, "https://example.com/clue.jpg"),
+        updatedAt: 20
+      })
+    );
+    const stopped = reduceHandoutSpotlightState(
+      updated,
+      createEnvelope("HANDOUT_SPOTLIGHT_UPDATE", "gm", {
+        handout: null,
+        updatedAt: 30
+      })
+    );
+
+    expect(started.handout?.imageUrl).toContain("scene.jpg");
+    expect(updated.handout?.imageUrl).toContain("clue.jpg");
+    expect(stopped.handout).toBeUndefined();
+    expect(stopped.updatedAt).toBe(30);
+  });
+
+  it("hydrates late joiners from snapshots and ignores stale updates", () => {
+    const hydrated = reduceHandoutSpotlightState(
+      baseState,
+      createEnvelope("HANDOUT_STATE_SNAPSHOT", "gm", {
+        handout: handout(20),
+        updatedAt: 20
+      })
+    );
+    const stale = reduceHandoutSpotlightState(
+      hydrated,
+      createEnvelope("HANDOUT_SPOTLIGHT_UPDATE", "gm", {
+        handout: handout(10, "https://example.com/stale.jpg"),
+        updatedAt: 10
+      })
+    );
+
+    expect(hydrated.handout?.title).toBe("The Observatory");
+    expect(stale.handout?.imageUrl).toContain("scene.jpg");
+    expect(Object.keys(stale.seenEventIds)).toHaveLength(2);
+  });
+
+  it("deduplicates event ids", () => {
+    const envelope = createEnvelope("HANDOUT_SPOTLIGHT_UPDATE", "gm", {
+      handout: handout(10),
+      updatedAt: 10
+    });
+    const started = reduceHandoutSpotlightState(baseState, envelope);
+
+    expect(reduceHandoutSpotlightState(started, envelope)).toBe(started);
+  });
+});

--- a/frontend/src/features/room-session/store/handoutSpotlightStore.ts
+++ b/frontend/src/features/room-session/store/handoutSpotlightStore.ts
@@ -1,0 +1,83 @@
+import { create } from "zustand";
+import type {
+  AnyProtocolEnvelope,
+  HandoutSpotlight,
+  HandoutSpotlightStatePayload,
+  ProtocolEnvelope
+} from "@/lib/protocol";
+
+export type HandoutSpotlightCoreState = {
+  handout?: HandoutSpotlight;
+  updatedAt: number;
+  seenEventIds: Record<string, true>;
+};
+
+type HandoutSpotlightActions = {
+  applyEnvelope: (envelope: AnyProtocolEnvelope) => void;
+  reset: () => void;
+};
+
+const MAX_SEEN_EVENT_IDS = 256;
+const initialState: HandoutSpotlightCoreState = {
+  handout: undefined,
+  updatedAt: 0,
+  seenEventIds: {}
+};
+
+export const useHandoutSpotlightStore = create<HandoutSpotlightCoreState & HandoutSpotlightActions>((set) => ({
+  ...initialState,
+  applyEnvelope: (envelope) => set((state) => reduceHandoutSpotlightState(state, envelope)),
+  reset: () => set(initialState)
+}));
+
+export function reduceHandoutSpotlightState(
+  state: HandoutSpotlightCoreState,
+  envelope: AnyProtocolEnvelope
+): HandoutSpotlightCoreState {
+  if (!isHandoutEnvelope(envelope)) {
+    return state;
+  }
+  if (state.seenEventIds[envelope.eventId]) {
+    return state;
+  }
+
+  const seenEventIds = appendSeenEventId(state.seenEventIds, envelope.eventId);
+  if (envelope.type === "HANDOUT_STATE_REQUEST") {
+    return { ...state, seenEventIds };
+  }
+  if (envelope.payload.updatedAt < state.updatedAt) {
+    return { ...state, seenEventIds };
+  }
+
+  return {
+    handout: envelope.payload.handout ?? undefined,
+    updatedAt: envelope.payload.updatedAt,
+    seenEventIds
+  };
+}
+
+function isHandoutEnvelope(envelope: AnyProtocolEnvelope): envelope is Extract<
+  AnyProtocolEnvelope,
+  | ProtocolEnvelope<"HANDOUT_STATE_REQUEST", Record<string, never>>
+  | ProtocolEnvelope<"HANDOUT_STATE_SNAPSHOT", HandoutSpotlightStatePayload>
+  | ProtocolEnvelope<"HANDOUT_SPOTLIGHT_UPDATE", HandoutSpotlightStatePayload>
+> {
+  return (
+    envelope.type === "HANDOUT_STATE_REQUEST" ||
+    envelope.type === "HANDOUT_STATE_SNAPSHOT" ||
+    envelope.type === "HANDOUT_SPOTLIGHT_UPDATE"
+  );
+}
+
+function appendSeenEventId(seenEventIds: Record<string, true>, eventId: string): Record<string, true> {
+  const nextSeen: Record<string, true> = { ...seenEventIds, [eventId]: true };
+  const eventIds = Object.keys(nextSeen);
+  if (eventIds.length <= MAX_SEEN_EVENT_IDS) {
+    return nextSeen;
+  }
+
+  for (const seenId of eventIds.slice(0, eventIds.length - MAX_SEEN_EVENT_IDS)) {
+    delete nextSeen[seenId];
+  }
+  return nextSeen;
+}

--- a/frontend/src/features/room-session/types.ts
+++ b/frontend/src/features/room-session/types.ts
@@ -1,7 +1,8 @@
 import type { Track } from "livekit-client";
-import type { SplitState, Whisper } from "@/lib/protocol";
+import type { HandoutSpotlight, SplitState, Whisper } from "@/lib/protocol";
 
 export type GameRole = "gamemaster" | "player";
+export type PlatformRole = "admin" | "user";
 
 export type VideoTileModel = {
   key: string;
@@ -111,6 +112,28 @@ export type VideoGridViewModel = {
 export type VideoGridActions = {
   onToggleParticipantSelection: (participantIdentity: string) => void;
   onToggleSpotlight: (participantIdentity: string | null) => Promise<void>;
+};
+
+export type HandoutControlPanelViewModel = {
+  handout?: HandoutSpotlight;
+  isPublishing: boolean;
+  commandError: string | null;
+};
+
+export type HandoutControlPanelActions = {
+  onBroadcast: (imageUrl: string, title: string) => Promise<CommandResult>;
+  onStop: () => Promise<CommandResult>;
+};
+
+export type HandoutSpotlightViewModel = {
+  handout?: HandoutSpotlight;
+  presenterLabel: string;
+  isMinimized: boolean;
+};
+
+export type HandoutSpotlightActions = {
+  onMinimize: () => void;
+  onRestore: () => void;
 };
 
 export type DevicePanelViewModel = {

--- a/frontend/src/lib/protocol.test.ts
+++ b/frontend/src/lib/protocol.test.ts
@@ -168,6 +168,50 @@ describe("parseProtocolEnvelope", () => {
     ).toBeNull();
   });
 
+  it("rejects malformed or unsafe handout spotlight payloads", () => {
+    const baseEnvelope = {
+      type: "HANDOUT_SPOTLIGHT_UPDATE",
+      v: 1,
+      eventId: "evt-handout",
+      actor: "gm",
+      ts: 1700000000000
+    };
+
+    expect(
+      parseProtocolEnvelope(
+        JSON.stringify({
+          ...baseEnvelope,
+          payload: {
+            handout: {
+              imageUrl: "javascript:alert(1)",
+              presenterIdentity: "gm",
+              presenterRole: "gamemaster",
+              updatedAt: 10
+            },
+            updatedAt: 10
+          }
+        })
+      )
+    ).toBeNull();
+
+    expect(
+      parseProtocolEnvelope(
+        JSON.stringify({
+          ...baseEnvelope,
+          payload: {
+            handout: {
+              imageUrl: "https://example.com/scene.jpg",
+              presenterIdentity: "gm",
+              presenterRole: "player",
+              updatedAt: 10
+            },
+            updatedAt: 10
+          }
+        })
+      )
+    ).toBeNull();
+  });
+
   it("parses a valid protocol envelope", () => {
     const raw = JSON.stringify({
       type: "SPOTLIGHT_UPDATE",
@@ -227,6 +271,38 @@ describe("parseProtocolEnvelope", () => {
         splitState: {
           gmIdentity: "gm",
           gmFocusRoomId: "side-1"
+        }
+      }
+    });
+  });
+
+  it("parses a valid handout spotlight update", () => {
+    const parsed = parseProtocolEnvelope(
+      JSON.stringify({
+        type: "HANDOUT_SPOTLIGHT_UPDATE",
+        v: 1,
+        eventId: "evt-handout",
+        actor: "gm",
+        ts: 1700000000000,
+        payload: {
+          handout: {
+            imageUrl: "https://example.com/scene.jpg",
+            title: "The ruined observatory",
+            presenterIdentity: "gm",
+            presenterRole: "gamemaster",
+            updatedAt: 1700000000000
+          },
+          updatedAt: 1700000000000
+        }
+      })
+    );
+
+    expect(parsed).toMatchObject({
+      type: "HANDOUT_SPOTLIGHT_UPDATE",
+      payload: {
+        handout: {
+          title: "The ruined observatory",
+          presenterIdentity: "gm"
         }
       }
     });

--- a/frontend/src/lib/protocol.ts
+++ b/frontend/src/lib/protocol.ts
@@ -26,6 +26,24 @@ export type SplitState = {
   updatedAt: number;
 };
 
+export const MAX_HANDOUT_URL_LENGTH = 2048;
+export const MAX_HANDOUT_TITLE_LENGTH = 80;
+
+export type HandoutPresenterRole = "gamemaster" | "admin";
+
+export type HandoutSpotlight = {
+  imageUrl: string;
+  title?: string;
+  presenterIdentity: string;
+  presenterRole: HandoutPresenterRole;
+  updatedAt: number;
+};
+
+export type HandoutSpotlightStatePayload = {
+  handout: HandoutSpotlight | null;
+  updatedAt: number;
+};
+
 export type ProtocolEventType =
   | "STATE_REQUEST"
   | "STATE_SNAPSHOT"
@@ -33,6 +51,9 @@ export type ProtocolEventType =
   | "WHISPER_UPDATE"
   | "WHISPER_CLOSE"
   | "SPOTLIGHT_UPDATE"
+  | "HANDOUT_STATE_REQUEST"
+  | "HANDOUT_STATE_SNAPSHOT"
+  | "HANDOUT_SPOTLIGHT_UPDATE"
   | "SPLIT_STATE_REQUEST"
   | "SPLIT_STATE_SNAPSHOT"
   | "SPLIT_START"
@@ -94,6 +115,9 @@ export type ProtocolPayloadByType = {
   WHISPER_UPDATE: Whisper;
   WHISPER_CLOSE: WhisperClosePayload;
   SPOTLIGHT_UPDATE: SpotlightPayload;
+  HANDOUT_STATE_REQUEST: Record<string, never>;
+  HANDOUT_STATE_SNAPSHOT: HandoutSpotlightStatePayload;
+  HANDOUT_SPOTLIGHT_UPDATE: HandoutSpotlightStatePayload;
   SPLIT_STATE_REQUEST: Record<string, never>;
   SPLIT_STATE_SNAPSHOT: SplitStateSnapshotPayload;
   SPLIT_START: SplitStateSnapshotPayload;
@@ -182,6 +206,9 @@ const protocolPayloadValidators: {
   WHISPER_UPDATE: isWhisper,
   WHISPER_CLOSE: isWhisperClosePayload,
   SPOTLIGHT_UPDATE: isSpotlightPayload,
+  HANDOUT_STATE_REQUEST: isEmptyRecord,
+  HANDOUT_STATE_SNAPSHOT: isHandoutSpotlightStatePayload,
+  HANDOUT_SPOTLIGHT_UPDATE: isHandoutSpotlightStatePayload,
   SPLIT_STATE_REQUEST: isEmptyRecord,
   SPLIT_STATE_SNAPSHOT: isSplitStateSnapshotPayload,
   SPLIT_START: isSplitStateSnapshotPayload,
@@ -222,6 +249,44 @@ function isWhisperClosePayload(payload: unknown): payload is WhisperClosePayload
 
 function isSpotlightPayload(payload: unknown): payload is SpotlightPayload {
   return isRecord(payload) && isNullableString(payload.identity) && isFiniteNumber(payload.updatedAt);
+}
+
+function isHandoutSpotlightStatePayload(payload: unknown): payload is HandoutSpotlightStatePayload {
+  if (!isRecord(payload) || !isFiniteNumber(payload.updatedAt)) {
+    return false;
+  }
+  if (payload.handout === null) {
+    return true;
+  }
+  return isHandoutSpotlight(payload.handout) && payload.handout.updatedAt === payload.updatedAt;
+}
+
+function isHandoutSpotlight(payload: unknown): payload is HandoutSpotlight {
+  return (
+    isRecord(payload) &&
+    isWebImageUrl(payload.imageUrl) &&
+    (payload.title === undefined ||
+      (typeof payload.title === "string" &&
+        payload.title.length > 0 &&
+        payload.title.length <= MAX_HANDOUT_TITLE_LENGTH)) &&
+    typeof payload.presenterIdentity === "string" &&
+    payload.presenterIdentity.length > 0 &&
+    (payload.presenterRole === "gamemaster" || payload.presenterRole === "admin") &&
+    isFiniteNumber(payload.updatedAt)
+  );
+}
+
+function isWebImageUrl(value: unknown): value is string {
+  if (typeof value !== "string" || value.length === 0 || value.length > MAX_HANDOUT_URL_LENGTH) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
 }
 
 function isSplitStateSnapshotPayload(payload: unknown): payload is SplitStateSnapshotPayload {


### PR DESCRIPTION
## Summary
- add GM/admin-authorized image handout broadcasts with update, stop, and late-join snapshots
- present handouts in a cinematic room-stage surface with local minimize/restore
- carry campaign-effective game and platform roles in trusted LiveKit participant attributes
- document and test protocol validation, authority, state reduction, and three-client synchronization

## Validation
- `cargo fmt --manifest-path backend/Cargo.toml -- --check`
- `cargo clippy --manifest-path backend/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path backend/Cargo.toml` (37 passed)
- `pnpm --filter frontend lint`
- `pnpm --filter frontend typecheck`
- `pnpm --filter frontend test` (97 passed)
- `pnpm --filter frontend build`
- Playwright full suite (12 passed, including 3-client handout lifecycle and late join)

Closes #129