### PR TITLE
feat(invites): add role-scoped campaign links

### DIFF
--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -15,7 +15,8 @@ use url::Url;
 
 use crate::{
     config::AppConfig,
-    error::{store_to_api_error, ApiError},
+    error::ApiError,
+    invites::{invite_error_code, invite_to_api_error, invite_token_from_next, InviteStoreError},
     state::AppState,
     users::{AuthUser, PlatformRole, StoreError},
 };
@@ -247,19 +248,17 @@ pub(crate) async fn handle_google_callback(
         return Ok((clear_jar, Redirect::to(&redirect)));
     }
 
-    let user = match state
-        .user_store
-        .authorize_google_user(
-            &google_user.email,
-            &google_user.sub,
-            google_user.name.as_deref(),
-        )
-        .await
+    let user = match authorize_user_for_next(
+        &state,
+        &next,
+        &google_user.email,
+        &google_user.sub,
+        google_user.name.as_deref(),
+    )
+    .await
     {
         Ok(user) => user,
-        Err(StoreError::UnknownUser(_))
-        | Err(StoreError::InactiveUser(_))
-        | Err(StoreError::GoogleSubjectMismatch(_, _)) => {
+        Err(LoginAuthorizationError::AccessDenied) => {
             let redirect = unauthorized_redirect(
                 &state.config,
                 "access_denied",
@@ -267,8 +266,11 @@ pub(crate) async fn handle_google_callback(
             )?;
             return Ok((clear_jar, Redirect::to(&redirect)));
         }
-        Err(err) => {
-            error!("authorize google user error: {err}");
+        Err(LoginAuthorizationError::Invite(err)) => {
+            let redirect = invite_failure_redirect(&state.config, &next, &err)?;
+            return Ok((clear_jar, Redirect::to(&redirect)));
+        }
+        Err(LoginAuthorizationError::Internal) => {
             return Err(ApiError::Internal);
         }
     };
@@ -313,21 +315,77 @@ pub(crate) async fn dev_login(
         .as_deref()
         .filter(|value| !value.trim().is_empty());
 
-    let user = state
-        .user_store
-        .authorize_google_user(
-            &normalized_email,
-            &dev_subject_for_email(&normalized_email),
-            display_name,
-        )
-        .await
-        .map_err(store_to_api_error)?;
+    let user = authorize_user_for_next(
+        &state,
+        &next,
+        &normalized_email,
+        &dev_subject_for_email(&normalized_email),
+        display_name,
+    )
+    .await
+    .map_err(|err| match err {
+        LoginAuthorizationError::AccessDenied => {
+            ApiError::Forbidden("your account is not authorized for this table".to_string())
+        }
+        LoginAuthorizationError::Invite(err) => invite_to_api_error(err),
+        LoginAuthorizationError::Internal => ApiError::Internal,
+    })?;
 
     let jar = create_session_cookie(&state, jar, &user).await?;
     Ok((
         jar,
         Redirect::to(&state.config.absolute_frontend_path(&next)),
     ))
+}
+
+async fn authorize_user_for_next(
+    state: &AppState,
+    next: &str,
+    email: &str,
+    subject: &str,
+    display_name: Option<&str>,
+) -> Result<AuthUser, LoginAuthorizationError> {
+    if let Some(invite_token) = invite_token_from_next(next) {
+        let redeemed = state
+            .invite_store
+            .redeem_invite(invite_token, email, subject, display_name)
+            .await
+            .map_err(LoginAuthorizationError::Invite)?;
+        let user = state
+            .user_store
+            .find_user_by_id(redeemed.user_id)
+            .await
+            .map_err(|err| {
+                error!("invite user lookup failed: {err}");
+                LoginAuthorizationError::Internal
+            })?
+            .ok_or(LoginAuthorizationError::Internal)?;
+        return if user.is_active {
+            Ok(user)
+        } else {
+            Err(LoginAuthorizationError::AccessDenied)
+        };
+    }
+
+    state
+        .user_store
+        .authorize_google_user(email, subject, display_name)
+        .await
+        .map_err(|err| match err {
+            StoreError::UnknownUser(_)
+            | StoreError::InactiveUser(_)
+            | StoreError::GoogleSubjectMismatch(_, _) => LoginAuthorizationError::AccessDenied,
+            other => {
+                error!("authorize google user error: {other}");
+                LoginAuthorizationError::Internal
+            }
+        })
+}
+
+enum LoginAuthorizationError {
+    AccessDenied,
+    Invite(InviteStoreError),
+    Internal,
 }
 
 async fn exchange_google_code(
@@ -464,6 +522,21 @@ fn unauthorized_redirect(
     if let Some(detail) = detail {
         url.query_pairs_mut().append_pair("detail", detail);
     }
+    Ok(url.to_string())
+}
+
+fn invite_failure_redirect(
+    config: &AppConfig,
+    next: &str,
+    error: &InviteStoreError,
+) -> Result<String, ApiError> {
+    let invite_path = config.absolute_frontend_path(next);
+    let mut url = Url::parse(&invite_path).map_err(|err| {
+        error!("invalid invite failure redirect url {invite_path}: {err}");
+        ApiError::Internal
+    })?;
+    url.query_pairs_mut()
+        .append_pair("error", invite_error_code(error));
     Ok(url.to_string())
 }
 

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -20,6 +20,8 @@ pub(crate) enum ApiError {
     Conflict(String),
     #[error("{0}")]
     NotFound(String),
+    #[error("{0}")]
+    Gone(String),
     #[error("bad request: {0}")]
     BadRequest(String),
     #[error("internal error")]
@@ -40,6 +42,7 @@ impl IntoResponse for ApiError {
             ApiError::Forbidden(_) => (StatusCode::FORBIDDEN, "FORBIDDEN", self.to_string()),
             ApiError::Conflict(_) => (StatusCode::CONFLICT, "CONFLICT", self.to_string()),
             ApiError::NotFound(_) => (StatusCode::NOT_FOUND, "NOT_FOUND", self.to_string()),
+            ApiError::Gone(_) => (StatusCode::GONE, "GONE", self.to_string()),
             ApiError::BadRequest(_) => (StatusCode::BAD_REQUEST, "BAD_REQUEST", self.to_string()),
             ApiError::Internal => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/invites.rs
+++ b/backend/src/invites.rs
@@ -1,0 +1,1098 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use axum_extra::extract::cookie::CookieJar;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use sqlx::{Row, SqlitePool};
+use thiserror::Error;
+use tracing::error;
+
+use crate::{
+    auth::{random_token, require_authenticated},
+    error::ApiError,
+    state::AppState,
+    users::{AuthUser, GameRole, PlatformRole},
+};
+
+const MAX_INVITE_USES: i64 = 1_000;
+const INVITE_TOKEN_BYTES: usize = 32;
+
+#[derive(Debug, Clone)]
+pub(crate) struct InviteStore {
+    pool: SqlitePool,
+}
+
+impl InviteStore {
+    pub(crate) async fn initialize(pool: SqlitePool) -> Result<Self, InviteStoreError> {
+        let store = Self { pool };
+        let mut tx = store.pool.begin().await?;
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS campaign_invites (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                campaign_id INTEGER NOT NULL REFERENCES campaign_presets(id) ON DELETE CASCADE,
+                token_hash TEXT NOT NULL UNIQUE,
+                token_hint TEXT NOT NULL,
+                role TEXT NOT NULL CHECK (role = 'player'),
+                expires_at INTEGER,
+                max_uses INTEGER CHECK (max_uses IS NULL OR max_uses > 0),
+                use_count INTEGER NOT NULL DEFAULT 0 CHECK (use_count >= 0),
+                created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+                revoked_at TEXT,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            "#,
+        )
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS campaign_invite_redemptions (
+                invite_id INTEGER NOT NULL REFERENCES campaign_invites(id) ON DELETE CASCADE,
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                redeemed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (invite_id, user_id)
+            )
+            "#,
+        )
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS invite_restricted_users (
+                user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            "#,
+        )
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS campaign_invites_campaign_id_idx ON campaign_invites(campaign_id)",
+        )
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(store)
+    }
+
+    pub(crate) async fn create_invite(
+        &self,
+        campaign_id: i64,
+        created_by_user_id: i64,
+        input: &CreateInviteInput,
+        raw_token: &str,
+    ) -> Result<CampaignInvite, InviteStoreError> {
+        let token_hash = hash_token(raw_token);
+        let token_hint = raw_token.chars().take(8).collect::<String>();
+        let result = sqlx::query(
+            r#"
+            INSERT INTO campaign_invites (
+                campaign_id, token_hash, token_hint, role, expires_at,
+                max_uses, created_by_user_id
+            ) VALUES (?, ?, ?, 'player', ?, ?, ?)
+            "#,
+        )
+        .bind(campaign_id)
+        .bind(token_hash)
+        .bind(token_hint)
+        .bind(input.expires_at)
+        .bind(input.max_uses)
+        .bind(created_by_user_id)
+        .execute(&self.pool)
+        .await?;
+        self.find_invite_by_id(result.last_insert_rowid())
+            .await?
+            .ok_or(InviteStoreError::InviteNotFound)
+    }
+
+    pub(crate) async fn list_invites(
+        &self,
+        campaign_id: i64,
+    ) -> Result<Vec<CampaignInvite>, InviteStoreError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT campaign_invites.id, campaign_invites.campaign_id,
+                   campaign_presets.display_name AS campaign_display_name,
+                   campaign_presets.room_slug, campaign_invites.token_hint,
+                   campaign_invites.role, campaign_invites.expires_at,
+                   campaign_invites.max_uses, campaign_invites.use_count,
+                   campaign_invites.revoked_at, campaign_invites.created_at
+            FROM campaign_invites
+            INNER JOIN campaign_presets ON campaign_presets.id = campaign_invites.campaign_id
+            WHERE campaign_invites.campaign_id = ?
+            ORDER BY campaign_invites.created_at DESC, campaign_invites.id DESC
+            "#,
+        )
+        .bind(campaign_id)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(invite_from_row).collect()
+    }
+
+    pub(crate) async fn revoke_invite(
+        &self,
+        campaign_id: i64,
+        invite_id: i64,
+    ) -> Result<(), InviteStoreError> {
+        let result = sqlx::query(
+            r#"
+            UPDATE campaign_invites
+            SET revoked_at = COALESCE(revoked_at, CURRENT_TIMESTAMP)
+            WHERE id = ? AND campaign_id = ?
+            "#,
+        )
+        .bind(invite_id)
+        .bind(campaign_id)
+        .execute(&self.pool)
+        .await?;
+        if result.rows_affected() == 0 {
+            return Err(InviteStoreError::InviteNotFound);
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn inspect_invite(
+        &self,
+        raw_token: &str,
+    ) -> Result<PublicInvite, InviteStoreError> {
+        let row = sqlx::query(
+            r#"
+            SELECT campaign_invites.id, campaign_invites.campaign_id,
+                   campaign_presets.display_name AS campaign_display_name,
+                   campaign_presets.room_slug, campaign_presets.is_archived,
+                   campaign_invites.token_hint, campaign_invites.role,
+                   campaign_invites.expires_at, campaign_invites.max_uses,
+                   campaign_invites.use_count, campaign_invites.revoked_at,
+                   campaign_invites.created_at
+            FROM campaign_invites
+            INNER JOIN campaign_presets ON campaign_presets.id = campaign_invites.campaign_id
+            WHERE campaign_invites.token_hash = ?
+            "#,
+        )
+        .bind(hash_token(raw_token))
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or(InviteStoreError::InviteNotFound)?;
+        let is_archived = row.get::<i64, _>("is_archived") != 0;
+        let invite = invite_from_row(row)?;
+        let status = if is_archived {
+            InviteStatus::Archived
+        } else {
+            invite.status
+        };
+        Ok(PublicInvite {
+            campaign_id: invite.campaign_id,
+            campaign_display_name: invite.campaign_display_name,
+            room_slug: invite.room_slug,
+            role: invite.role,
+            expires_at: invite.expires_at,
+            status,
+        })
+    }
+
+    pub(crate) async fn redeem_invite(
+        &self,
+        raw_token: &str,
+        email: &str,
+        google_subject: &str,
+        display_name: Option<&str>,
+    ) -> Result<RedeemedInvite, InviteStoreError> {
+        let normalized_email = email.trim().to_lowercase();
+        if normalized_email.is_empty() || google_subject.trim().is_empty() {
+            return Err(InviteStoreError::InvalidIdentity);
+        }
+        let now = Utc::now().timestamp();
+        let mut tx = self.pool.begin().await?;
+        let row = sqlx::query(
+            r#"
+            SELECT campaign_invites.id, campaign_invites.campaign_id,
+                   campaign_presets.display_name AS campaign_display_name,
+                   campaign_presets.room_slug, campaign_presets.is_archived,
+                   campaign_invites.expires_at, campaign_invites.max_uses,
+                   campaign_invites.use_count, campaign_invites.revoked_at
+            FROM campaign_invites
+            INNER JOIN campaign_presets ON campaign_presets.id = campaign_invites.campaign_id
+            WHERE campaign_invites.token_hash = ?
+            "#,
+        )
+        .bind(hash_token(raw_token))
+        .fetch_optional(&mut *tx)
+        .await?
+        .ok_or(InviteStoreError::InviteNotFound)?;
+        let invite_id = row.get::<i64, _>("id");
+        let campaign_id = row.get::<i64, _>("campaign_id");
+        let campaign_display_name = row.get::<String, _>("campaign_display_name");
+        let room_slug = row.get::<String, _>("room_slug");
+
+        let existing = sqlx::query(
+            "SELECT id, google_subject, platform_role, game_role, is_active FROM users WHERE normalized_email = ?",
+        )
+        .bind(&normalized_email)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if let Some(existing) = existing.as_ref() {
+            let is_privileged = existing.get::<String, _>("platform_role") == "admin"
+                || existing.get::<String, _>("game_role") == "gamemaster";
+            if existing.get::<i64, _>("is_active") == 0 && is_privileged {
+                return Err(InviteStoreError::PrivilegedIdentity);
+            }
+            let existing_subject = existing.get::<Option<String>, _>("google_subject");
+            if existing_subject
+                .as_deref()
+                .is_some_and(|subject| subject != google_subject)
+            {
+                return Err(InviteStoreError::IdentityMismatch);
+            }
+            let user_id = existing.get::<i64, _>("id");
+            let already_redeemed = sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM campaign_invite_redemptions WHERE invite_id = ? AND user_id = ?",
+            )
+            .bind(invite_id)
+            .bind(user_id)
+            .fetch_one(&mut *tx)
+            .await?
+                > 0;
+            if already_redeemed {
+                tx.commit().await?;
+                return Ok(RedeemedInvite {
+                    user_id,
+                    campaign_id,
+                    campaign_display_name,
+                    room_slug,
+                });
+            }
+        }
+
+        validate_redeemable_row(&row, now)?;
+
+        let (user_id, created_user) = if let Some(existing) = existing {
+            let user_id = existing.get::<i64, _>("id");
+            sqlx::query(
+                r#"
+                UPDATE users
+                SET email = ?, display_name = COALESCE(?, display_name),
+                    google_subject = COALESCE(google_subject, ?), is_active = 1,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                "#,
+            )
+            .bind(email.trim())
+            .bind(clean_optional_text(display_name))
+            .bind(google_subject)
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
+            (user_id, false)
+        } else {
+            let result = sqlx::query(
+                r#"
+                INSERT INTO users (
+                    email, normalized_email, display_name, google_subject,
+                    platform_role, game_role, is_active
+                ) VALUES (?, ?, ?, ?, 'user', 'player', 1)
+                "#,
+            )
+            .bind(email.trim())
+            .bind(&normalized_email)
+            .bind(clean_optional_text(display_name))
+            .bind(google_subject)
+            .execute(&mut *tx)
+            .await?;
+            (result.last_insert_rowid(), true)
+        };
+
+        let consumed = sqlx::query(
+            r#"
+            UPDATE campaign_invites
+            SET use_count = use_count + 1
+            WHERE id = ? AND revoked_at IS NULL
+              AND (expires_at IS NULL OR expires_at > ?)
+              AND (max_uses IS NULL OR use_count < max_uses)
+            "#,
+        )
+        .bind(invite_id)
+        .bind(now)
+        .execute(&mut *tx)
+        .await?;
+        if consumed.rows_affected() != 1 {
+            return Err(InviteStoreError::Exhausted);
+        }
+        sqlx::query("INSERT INTO campaign_invite_redemptions (invite_id, user_id) VALUES (?, ?)")
+            .bind(invite_id)
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(
+            r#"
+            INSERT INTO campaign_members (campaign_id, user_id, game_role)
+            VALUES (?, ?, 'player')
+            ON CONFLICT(campaign_id, user_id) DO NOTHING
+            "#,
+        )
+        .bind(campaign_id)
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await?;
+        if created_user {
+            sqlx::query("INSERT INTO invite_restricted_users (user_id) VALUES (?)")
+                .bind(user_id)
+                .execute(&mut *tx)
+                .await?;
+        }
+        tx.commit().await?;
+        Ok(RedeemedInvite {
+            user_id,
+            campaign_id,
+            campaign_display_name,
+            room_slug,
+        })
+    }
+
+    pub(crate) async fn is_user_invite_restricted(
+        &self,
+        user_id: i64,
+    ) -> Result<bool, InviteStoreError> {
+        let count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM invite_restricted_users WHERE user_id = ?",
+        )
+        .bind(user_id)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(count > 0)
+    }
+
+    async fn find_invite_by_id(
+        &self,
+        invite_id: i64,
+    ) -> Result<Option<CampaignInvite>, InviteStoreError> {
+        let row = sqlx::query(
+            r#"
+            SELECT campaign_invites.id, campaign_invites.campaign_id,
+                   campaign_presets.display_name AS campaign_display_name,
+                   campaign_presets.room_slug, campaign_invites.token_hint,
+                   campaign_invites.role, campaign_invites.expires_at,
+                   campaign_invites.max_uses, campaign_invites.use_count,
+                   campaign_invites.revoked_at, campaign_invites.created_at
+            FROM campaign_invites
+            INNER JOIN campaign_presets ON campaign_presets.id = campaign_invites.campaign_id
+            WHERE campaign_invites.id = ?
+            "#,
+        )
+        .bind(invite_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(invite_from_row).transpose()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CreateInviteInput {
+    pub(crate) expires_at: Option<i64>,
+    pub(crate) max_uses: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(crate) enum InviteRole {
+    Player,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(crate) enum InviteStatus {
+    Active,
+    Revoked,
+    Expired,
+    Exhausted,
+    Archived,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct CampaignInvite {
+    pub(crate) id: i64,
+    pub(crate) campaign_id: i64,
+    pub(crate) campaign_display_name: String,
+    pub(crate) room_slug: String,
+    pub(crate) token_hint: String,
+    pub(crate) role: InviteRole,
+    pub(crate) expires_at: Option<i64>,
+    pub(crate) max_uses: Option<i64>,
+    pub(crate) use_count: i64,
+    pub(crate) status: InviteStatus,
+    pub(crate) revoked_at: Option<String>,
+    pub(crate) created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct PublicInvite {
+    pub(crate) campaign_id: i64,
+    pub(crate) campaign_display_name: String,
+    pub(crate) room_slug: String,
+    pub(crate) role: InviteRole,
+    pub(crate) expires_at: Option<i64>,
+    pub(crate) status: InviteStatus,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RedeemedInvite {
+    pub(crate) user_id: i64,
+    pub(crate) campaign_id: i64,
+    pub(crate) campaign_display_name: String,
+    pub(crate) room_slug: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct CreateInviteRequest {
+    role: InviteRole,
+    expires_at: Option<i64>,
+    max_uses: Option<i64>,
+}
+
+impl CreateInviteRequest {
+    fn validate(&self) -> Result<CreateInviteInput, ApiError> {
+        if self.role != InviteRole::Player {
+            return Err(ApiError::BadRequest(
+                "invites may only grant player access".to_string(),
+            ));
+        }
+        if self
+            .expires_at
+            .is_some_and(|value| value <= Utc::now().timestamp())
+        {
+            return Err(ApiError::BadRequest(
+                "invite expiry must be in the future".to_string(),
+            ));
+        }
+        if self
+            .max_uses
+            .is_some_and(|value| !(1..=MAX_INVITE_USES).contains(&value))
+        {
+            return Err(ApiError::BadRequest(format!(
+                "invite max uses must be between 1 and {MAX_INVITE_USES}"
+            )));
+        }
+        Ok(CreateInviteInput {
+            expires_at: self.expires_at,
+            max_uses: self.max_uses,
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct CampaignInvitesResponse {
+    invites: Vec<CampaignInvite>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct CreatedInviteResponse {
+    invite: CampaignInvite,
+    token: String,
+    path: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct RedeemedInviteResponse {
+    campaign_id: i64,
+    campaign_display_name: String,
+    room_slug: String,
+}
+
+pub(crate) async fn list_campaign_invites(
+    State(state): State<Arc<AppState>>,
+    jar: CookieJar,
+    Path(campaign_id): Path<i64>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_invite_manager(&state, &jar, campaign_id).await?;
+    let invites = state
+        .invite_store
+        .list_invites(campaign_id)
+        .await
+        .map_err(invite_to_api_error)?;
+    Ok(Json(CampaignInvitesResponse { invites }))
+}
+
+pub(crate) async fn create_campaign_invite(
+    State(state): State<Arc<AppState>>,
+    jar: CookieJar,
+    Path(campaign_id): Path<i64>,
+    Json(request): Json<CreateInviteRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let manager = require_invite_manager(&state, &jar, campaign_id).await?;
+    let campaign = state
+        .user_store
+        .find_campaign_by_id(campaign_id)
+        .await
+        .map_err(|err| {
+            error!("campaign lookup for invite failed: {err}");
+            ApiError::Internal
+        })?
+        .ok_or_else(|| ApiError::NotFound("campaign not found".to_string()))?;
+    if campaign.is_archived {
+        return Err(ApiError::Conflict(
+            "archived campaigns cannot issue invites".to_string(),
+        ));
+    }
+    let input = request.validate()?;
+    let token = random_token(INVITE_TOKEN_BYTES)?;
+    let invite = state
+        .invite_store
+        .create_invite(campaign_id, manager.id, &input, &token)
+        .await
+        .map_err(invite_to_api_error)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(CreatedInviteResponse {
+            path: format!("/invite/{token}"),
+            invite,
+            token,
+        }),
+    ))
+}
+
+pub(crate) async fn revoke_campaign_invite(
+    State(state): State<Arc<AppState>>,
+    jar: CookieJar,
+    Path((campaign_id, invite_id)): Path<(i64, i64)>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_invite_manager(&state, &jar, campaign_id).await?;
+    state
+        .invite_store
+        .revoke_invite(campaign_id, invite_id)
+        .await
+        .map_err(invite_to_api_error)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub(crate) async fn inspect_campaign_invite(
+    State(state): State<Arc<AppState>>,
+    Path(token): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let invite = state
+        .invite_store
+        .inspect_invite(&token)
+        .await
+        .map_err(invite_to_api_error)?;
+    Ok(Json(invite))
+}
+
+pub(crate) async fn redeem_campaign_invite(
+    State(state): State<Arc<AppState>>,
+    jar: CookieJar,
+    Path(token): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = require_authenticated(&state, &jar).await?;
+    let subject = user.google_subject.as_deref().ok_or_else(|| {
+        ApiError::Forbidden("authenticated user is missing Google identity".to_string())
+    })?;
+    let redeemed = state
+        .invite_store
+        .redeem_invite(&token, &user.email, subject, user.display_name.as_deref())
+        .await
+        .map_err(invite_to_api_error)?;
+    Ok(Json(redeemed_response(redeemed)))
+}
+
+async fn require_invite_manager(
+    state: &AppState,
+    jar: &CookieJar,
+    campaign_id: i64,
+) -> Result<AuthUser, ApiError> {
+    let manager = require_authenticated(state, jar).await?;
+    if manager.platform_role != PlatformRole::Admin && manager.game_role != GameRole::Gamemaster {
+        return Err(ApiError::Forbidden(
+            "gamemaster or admin access is required".to_string(),
+        ));
+    }
+    let allowed = state
+        .user_store
+        .user_can_manage_campaign(
+            campaign_id,
+            manager.id,
+            manager.platform_role == PlatformRole::Admin,
+        )
+        .await
+        .map_err(|err| {
+            error!("invite ownership check failed: {err}");
+            ApiError::Internal
+        })?;
+    if !allowed {
+        return Err(ApiError::Forbidden(
+            "you do not manage this campaign".to_string(),
+        ));
+    }
+    Ok(manager)
+}
+
+pub(crate) fn invite_token_from_next(next: &str) -> Option<&str> {
+    let path = next.split('?').next()?;
+    let token = path.strip_prefix("/invite/")?;
+    if token.is_empty() || token.contains('/') {
+        None
+    } else {
+        Some(token)
+    }
+}
+
+pub(crate) fn invite_error_code(error: &InviteStoreError) -> &'static str {
+    match error {
+        InviteStoreError::InviteNotFound => "invalid",
+        InviteStoreError::Revoked => "revoked",
+        InviteStoreError::Expired => "expired",
+        InviteStoreError::Exhausted => "exhausted",
+        InviteStoreError::CampaignArchived => "archived",
+        InviteStoreError::IdentityMismatch | InviteStoreError::InvalidIdentity => "identity",
+        InviteStoreError::PrivilegedIdentity => "privileged",
+        InviteStoreError::Sqlx(_) => "internal",
+    }
+}
+
+pub(crate) fn invite_to_api_error(error: InviteStoreError) -> ApiError {
+    match error {
+        InviteStoreError::InviteNotFound => {
+            ApiError::NotFound("invite link is invalid".to_string())
+        }
+        InviteStoreError::Revoked => ApiError::Gone("invite link has been revoked".to_string()),
+        InviteStoreError::Expired => ApiError::Gone("invite link has expired".to_string()),
+        InviteStoreError::Exhausted => {
+            ApiError::Gone("invite link has reached its maximum uses".to_string())
+        }
+        InviteStoreError::CampaignArchived => {
+            ApiError::Gone("this campaign is archived".to_string())
+        }
+        InviteStoreError::IdentityMismatch => {
+            ApiError::Forbidden("invite email is linked to another identity".to_string())
+        }
+        InviteStoreError::InvalidIdentity => {
+            ApiError::BadRequest("invite identity is invalid".to_string())
+        }
+        InviteStoreError::PrivilegedIdentity => ApiError::Forbidden(
+            "an invite cannot reactivate an administrator or gamemaster".to_string(),
+        ),
+        InviteStoreError::Sqlx(error) => {
+            error!("invite store error: {error}");
+            ApiError::Internal
+        }
+    }
+}
+
+fn redeemed_response(redeemed: RedeemedInvite) -> RedeemedInviteResponse {
+    RedeemedInviteResponse {
+        campaign_id: redeemed.campaign_id,
+        campaign_display_name: redeemed.campaign_display_name,
+        room_slug: redeemed.room_slug,
+    }
+}
+
+fn validate_redeemable_row(
+    row: &sqlx::sqlite::SqliteRow,
+    now: i64,
+) -> Result<(), InviteStoreError> {
+    if row.get::<i64, _>("is_archived") != 0 {
+        return Err(InviteStoreError::CampaignArchived);
+    }
+    if row.get::<Option<String>, _>("revoked_at").is_some() {
+        return Err(InviteStoreError::Revoked);
+    }
+    if row
+        .get::<Option<i64>, _>("expires_at")
+        .is_some_and(|expires_at| expires_at <= now)
+    {
+        return Err(InviteStoreError::Expired);
+    }
+    let max_uses = row.get::<Option<i64>, _>("max_uses");
+    let use_count = row.get::<i64, _>("use_count");
+    if max_uses.is_some_and(|max_uses| use_count >= max_uses) {
+        return Err(InviteStoreError::Exhausted);
+    }
+    Ok(())
+}
+
+fn invite_from_row(row: sqlx::sqlite::SqliteRow) -> Result<CampaignInvite, InviteStoreError> {
+    let role = match row.get::<String, _>("role").as_str() {
+        "player" => InviteRole::Player,
+        _ => return Err(InviteStoreError::InvalidIdentity),
+    };
+    let expires_at = row.get::<Option<i64>, _>("expires_at");
+    let max_uses = row.get::<Option<i64>, _>("max_uses");
+    let use_count = row.get::<i64, _>("use_count");
+    let revoked_at = row.get::<Option<String>, _>("revoked_at");
+    let status = if revoked_at.is_some() {
+        InviteStatus::Revoked
+    } else if expires_at.is_some_and(|expires_at| expires_at <= Utc::now().timestamp()) {
+        InviteStatus::Expired
+    } else if max_uses.is_some_and(|max_uses| use_count >= max_uses) {
+        InviteStatus::Exhausted
+    } else {
+        InviteStatus::Active
+    };
+    Ok(CampaignInvite {
+        id: row.get("id"),
+        campaign_id: row.get("campaign_id"),
+        campaign_display_name: row.get("campaign_display_name"),
+        room_slug: row.get("room_slug"),
+        token_hint: row.get("token_hint"),
+        role,
+        expires_at,
+        max_uses,
+        use_count,
+        status,
+        revoked_at,
+        created_at: row.get("created_at"),
+    })
+}
+
+fn clean_optional_text(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn hash_token(raw_token: &str) -> String {
+    URL_SAFE_NO_PAD.encode(Sha256::digest(raw_token.as_bytes()))
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum InviteStoreError {
+    #[error("invite link is invalid")]
+    InviteNotFound,
+    #[error("invite link has been revoked")]
+    Revoked,
+    #[error("invite link has expired")]
+    Expired,
+    #[error("invite link has reached its maximum uses")]
+    Exhausted,
+    #[error("campaign is archived")]
+    CampaignArchived,
+    #[error("identity is already linked to another account")]
+    IdentityMismatch,
+    #[error("identity is invalid")]
+    InvalidIdentity,
+    #[error("invite cannot reactivate a privileged identity")]
+    PrivilegedIdentity,
+    #[error("database error: {0}")]
+    Sqlx(#[from] sqlx::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::users::{build_bootstrap_users, CampaignInput, UserPatch, UserStore};
+
+    async fn stores() -> (UserStore, InviteStore, i64, i64) {
+        let users = UserStore::connect("sqlite::memory:").await.unwrap();
+        let invite_store = InviteStore::initialize(users.sqlite_pool()).await.unwrap();
+        let bootstrap = build_bootstrap_users(
+            &[],
+            &["gm@example.com".to_string()],
+            &["player@example.com".to_string()],
+        )
+        .unwrap();
+        users.seed_bootstrap_users(&bootstrap).await.unwrap();
+        let gm = users
+            .find_user_by_email("gm@example.com")
+            .await
+            .unwrap()
+            .unwrap();
+        let player = users
+            .find_user_by_email("player@example.com")
+            .await
+            .unwrap()
+            .unwrap();
+        let campaign = users
+            .create_campaign(
+                gm.id,
+                CampaignInput {
+                    display_name: "Thursday Night".to_string(),
+                    room_slug: "thursday-night".to_string(),
+                    gamemaster_user_ids: vec![gm.id],
+                    player_user_ids: vec![],
+                    default_split_room_names: vec![],
+                    is_archived: false,
+                },
+            )
+            .await
+            .unwrap();
+        (users, invite_store, campaign.id, player.id)
+    }
+
+    #[tokio::test]
+    async fn redemption_creates_restricted_player_and_is_idempotent() {
+        let (users, invites, campaign_id, _) = stores().await;
+        invites
+            .create_invite(
+                campaign_id,
+                1,
+                &CreateInviteInput {
+                    expires_at: None,
+                    max_uses: Some(1),
+                },
+                "secret-token",
+            )
+            .await
+            .unwrap();
+
+        let first = invites
+            .redeem_invite(
+                "secret-token",
+                "guest@example.com",
+                "google-guest",
+                Some("Guest"),
+            )
+            .await
+            .unwrap();
+        let second = invites
+            .redeem_invite(
+                "secret-token",
+                "guest@example.com",
+                "google-guest",
+                Some("Guest"),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(first.user_id, second.user_id);
+        let user = users
+            .find_user_by_email("guest@example.com")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(user.platform_role, PlatformRole::User);
+        assert_eq!(user.game_role, GameRole::Player);
+        assert_eq!(
+            users
+                .campaign_role_for_user(campaign_id, user.id)
+                .await
+                .unwrap(),
+            Some(GameRole::Player)
+        );
+        assert!(invites.is_user_invite_restricted(user.id).await.unwrap());
+        assert_eq!(
+            invites.list_invites(campaign_id).await.unwrap()[0].use_count,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn max_use_expiry_and_revocation_are_enforced() {
+        let (_users, invites, campaign_id, _) = stores().await;
+        let input = CreateInviteInput {
+            expires_at: None,
+            max_uses: Some(1),
+        };
+        let invite = invites
+            .create_invite(campaign_id, 1, &input, "single-use")
+            .await
+            .unwrap();
+        invites
+            .redeem_invite("single-use", "one@example.com", "subject-one", None)
+            .await
+            .unwrap();
+        assert!(matches!(
+            invites
+                .redeem_invite("single-use", "two@example.com", "subject-two", None)
+                .await,
+            Err(InviteStoreError::Exhausted)
+        ));
+
+        let revoked = invites
+            .create_invite(campaign_id, 1, &input, "revoked")
+            .await
+            .unwrap();
+        invites
+            .revoke_invite(campaign_id, revoked.id)
+            .await
+            .unwrap();
+        assert!(matches!(
+            invites
+                .redeem_invite("revoked", "three@example.com", "subject-three", None)
+                .await,
+            Err(InviteStoreError::Revoked)
+        ));
+
+        invites
+            .create_invite(
+                campaign_id,
+                1,
+                &CreateInviteInput {
+                    expires_at: Some(Utc::now().timestamp() - 1),
+                    max_uses: None,
+                },
+                "expired",
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            invites
+                .redeem_invite("expired", "four@example.com", "subject-four", None)
+                .await,
+            Err(InviteStoreError::Expired)
+        ));
+        assert_eq!(invite.status, InviteStatus::Active);
+    }
+
+    #[tokio::test]
+    async fn redemption_never_promotes_existing_player() {
+        let (users, invites, campaign_id, player_id) = stores().await;
+        invites
+            .create_invite(
+                campaign_id,
+                1,
+                &CreateInviteInput {
+                    expires_at: None,
+                    max_uses: None,
+                },
+                "player-only",
+            )
+            .await
+            .unwrap();
+        invites
+            .redeem_invite(
+                "player-only",
+                "player@example.com",
+                "google-player",
+                Some("Player"),
+            )
+            .await
+            .unwrap();
+        let user = users.find_user_by_id(player_id).await.unwrap().unwrap();
+        assert_eq!(user.platform_role, PlatformRole::User);
+        assert_eq!(user.game_role, GameRole::Player);
+        assert_eq!(
+            users
+                .campaign_role_for_user(campaign_id, player_id)
+                .await
+                .unwrap(),
+            Some(GameRole::Player)
+        );
+    }
+
+    #[tokio::test]
+    async fn invite_cannot_reactivate_a_privileged_user() {
+        let (users, invites, campaign_id, _) = stores().await;
+        let gm = users
+            .find_user_by_email("gm@example.com")
+            .await
+            .unwrap()
+            .unwrap();
+        users
+            .update_user(
+                gm.id,
+                UserPatch {
+                    is_active: Some(false),
+                    ..UserPatch::default()
+                },
+            )
+            .await
+            .unwrap();
+        invites
+            .create_invite(
+                campaign_id,
+                gm.id,
+                &CreateInviteInput {
+                    expires_at: None,
+                    max_uses: None,
+                },
+                "no-privilege-reactivation",
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            invites
+                .redeem_invite(
+                    "no-privilege-reactivation",
+                    "gm@example.com",
+                    "google-gm",
+                    Some("GM"),
+                )
+                .await,
+            Err(InviteStoreError::PrivilegedIdentity)
+        ));
+    }
+
+    #[tokio::test]
+    async fn invites_survive_database_reconnect_without_persisting_the_raw_token() {
+        let path = std::env::temp_dir().join(format!(
+            "virtual-table-invite-{}-{}.sqlite",
+            std::process::id(),
+            Utc::now().timestamp_micros()
+        ));
+        std::fs::File::create(&path).unwrap();
+        let database_url = format!("sqlite://{}", path.display());
+        let users = UserStore::connect(&database_url).await.unwrap();
+        let invites = InviteStore::initialize(users.sqlite_pool()).await.unwrap();
+        let bootstrap = build_bootstrap_users(&[], &["gm@example.com".to_string()], &[]).unwrap();
+        users.seed_bootstrap_users(&bootstrap).await.unwrap();
+        let gm = users
+            .find_user_by_email("gm@example.com")
+            .await
+            .unwrap()
+            .unwrap();
+        let campaign = users
+            .create_campaign(
+                gm.id,
+                CampaignInput {
+                    display_name: "Persistent Invite Table".to_string(),
+                    room_slug: "persistent-invite-table".to_string(),
+                    gamemaster_user_ids: vec![gm.id],
+                    player_user_ids: vec![],
+                    default_split_room_names: vec![],
+                    is_archived: false,
+                },
+            )
+            .await
+            .unwrap();
+        invites
+            .create_invite(
+                campaign.id,
+                gm.id,
+                &CreateInviteInput {
+                    expires_at: None,
+                    max_uses: Some(3),
+                },
+                "raw-token-is-not-stored",
+            )
+            .await
+            .unwrap();
+        users.sqlite_pool().close().await;
+
+        let reopened_users = UserStore::connect(&database_url).await.unwrap();
+        let reopened_pool = reopened_users.sqlite_pool();
+        let reopened_invites = InviteStore::initialize(reopened_pool.clone())
+            .await
+            .unwrap();
+        let persisted = reopened_invites.list_invites(campaign.id).await.unwrap();
+        assert_eq!(persisted.len(), 1);
+        assert_eq!(persisted[0].token_hint, "raw-toke");
+        assert_eq!(persisted[0].max_uses, Some(3));
+        assert_eq!(
+            reopened_invites
+                .inspect_invite("raw-token-is-not-stored")
+                .await
+                .unwrap()
+                .status,
+            InviteStatus::Active
+        );
+        let raw_token_count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM campaign_invites WHERE token_hash = ?",
+        )
+        .bind("raw-token-is-not-stored")
+        .fetch_one(&reopened_pool)
+        .await
+        .unwrap();
+        assert_eq!(raw_token_count, 0);
+
+        reopened_pool.close().await;
+        std::fs::remove_file(path).unwrap();
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3,6 +3,7 @@ mod auth;
 mod campaigns;
 mod config;
 mod error;
+mod invites;
 mod router;
 mod session;
 mod state;
@@ -15,6 +16,7 @@ use reqwest::Client;
 use tracing::{error, info};
 
 use config::AppConfig;
+use invites::InviteStore;
 use router::build_router;
 use state::AppState;
 use users::UserStore;
@@ -52,6 +54,14 @@ async fn main() {
         std::process::exit(1);
     }
 
+    let invite_store = match InviteStore::initialize(user_store.sqlite_pool()).await {
+        Ok(store) => store,
+        Err(err) => {
+            error!("invite store init error: {err}");
+            std::process::exit(1);
+        }
+    };
+
     let bind_addr: SocketAddr = config
         .bind_addr
         .parse()
@@ -75,6 +85,7 @@ async fn main() {
     let state = Arc::new(AppState {
         http_client,
         config,
+        invite_store,
         user_store,
     });
     let app = build_router(state);

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -24,6 +24,10 @@ use crate::{
         list_managed_campaigns, update_campaign,
     },
     error::ApiError,
+    invites::{
+        create_campaign_invite, inspect_campaign_invite, list_campaign_invites,
+        redeem_campaign_invite, revoke_campaign_invite,
+    },
     session::{get_session, logout},
     state::AppState,
     token::mint_token,
@@ -49,6 +53,19 @@ pub(crate) fn build_router(state: Arc<AppState>) -> Router {
         .route(
             "/api/v1/campaigns/manage/{campaign_id}",
             patch(update_campaign).delete(archive_campaign),
+        )
+        .route(
+            "/api/v1/campaigns/manage/{campaign_id}/invites",
+            get(list_campaign_invites).post(create_campaign_invite),
+        )
+        .route(
+            "/api/v1/campaigns/manage/{campaign_id}/invites/{invite_id}",
+            axum::routing::delete(revoke_campaign_invite),
+        )
+        .route("/api/v1/invites/{token}", get(inspect_campaign_invite))
+        .route(
+            "/api/v1/invites/{token}/redeem",
+            post(redeem_campaign_invite),
         )
         .route(
             "/api/v1/admin/users",
@@ -105,8 +122,11 @@ mod tests {
         admin::AdminUsersResponse,
         auth::{random_token, signed_value, SESSION_COOKIE_NAME},
         config::{parse_optional_set, AppConfig},
+        invites::{CreateInviteInput, InviteStore},
         token::{derive_room_identity, LiveKitClaims, TokenResponse},
-        users::{build_bootstrap_users, CampaignPreset, PlatformRole, UserStore},
+        users::{
+            build_bootstrap_users, CampaignInput, CampaignPreset, GameRole, PlatformRole, UserStore,
+        },
     };
     use axum::{body::Body, http::Request, http::StatusCode};
     use chrono::{Duration, Utc};
@@ -117,6 +137,9 @@ mod tests {
 
     async fn test_state() -> Arc<AppState> {
         let user_store = UserStore::connect("sqlite::memory:").await.unwrap();
+        let invite_store = InviteStore::initialize(user_store.sqlite_pool())
+            .await
+            .unwrap();
         let bootstrap_users = build_bootstrap_users(
             &["gm@example.com".to_string()],
             &[
@@ -155,6 +178,7 @@ mod tests {
                 secure_cookies: false,
                 enable_dev_login: true,
             },
+            invite_store,
             user_store,
         })
     }
@@ -664,5 +688,180 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(invalid_member_response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn campaign_invites_are_visible_only_to_their_gamemasters_and_admins() {
+        let state = test_state().await;
+        let admin = state
+            .user_store
+            .find_user_by_email("gm@example.com")
+            .await
+            .unwrap()
+            .unwrap();
+        let campaign = state
+            .user_store
+            .create_campaign(
+                admin.id,
+                CampaignInput {
+                    display_name: "Private Invite Ledger".to_string(),
+                    room_slug: "private-invite-ledger".to_string(),
+                    gamemaster_user_ids: vec![admin.id],
+                    player_user_ids: vec![],
+                    default_split_room_names: vec![],
+                    is_archived: false,
+                },
+            )
+            .await
+            .unwrap();
+        state
+            .invite_store
+            .create_invite(
+                campaign.id,
+                admin.id,
+                &CreateInviteInput {
+                    expires_at: None,
+                    max_uses: None,
+                },
+                "private-ledger-token",
+            )
+            .await
+            .unwrap();
+        let admin_cookie = session_cookie_for(&state, "gm@example.com", "google-gm").await;
+        let unrelated_gm_cookie =
+            session_cookie_for(&state, "other-gm@example.com", "google-other-gm").await;
+        let player_cookie = session_cookie_for(&state, "player@example.com", "google-player").await;
+        let app = build_router(state);
+        let uri = format!("/api/v1/campaigns/manage/{}/invites", campaign.id);
+
+        for (cookie, expected) in [
+            (admin_cookie, StatusCode::OK),
+            (unrelated_gm_cookie, StatusCode::FORBIDDEN),
+            (player_cookie, StatusCode::FORBIDDEN),
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(&uri)
+                        .header("cookie", cookie)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn invite_dev_login_provisions_only_campaign_player_access() {
+        let state = test_state().await;
+        let gm = state
+            .user_store
+            .find_user_by_email("gm@example.com")
+            .await
+            .unwrap()
+            .unwrap();
+        let campaign = state
+            .user_store
+            .create_campaign(
+                gm.id,
+                CampaignInput {
+                    display_name: "Invite Table".to_string(),
+                    room_slug: "invite-table".to_string(),
+                    gamemaster_user_ids: vec![gm.id],
+                    player_user_ids: vec![],
+                    default_split_room_names: vec![],
+                    is_archived: false,
+                },
+            )
+            .await
+            .unwrap();
+        state
+            .invite_store
+            .create_invite(
+                campaign.id,
+                gm.id,
+                &CreateInviteInput {
+                    expires_at: None,
+                    max_uses: Some(1),
+                },
+                "guest-secret",
+            )
+            .await
+            .unwrap();
+        let app = build_router(state.clone());
+
+        let login = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/auth/dev-login?email=guest%40example.com&name=Guest&next=%2Finvite%2Fguest-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(login.status(), StatusCode::SEE_OTHER);
+        let cookie = login
+            .headers()
+            .get("set-cookie")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .split(';')
+            .next()
+            .unwrap()
+            .to_string();
+        let guest = state
+            .user_store
+            .find_user_by_email("guest@example.com")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(guest.platform_role, PlatformRole::User);
+        assert_eq!(guest.game_role, GameRole::Player);
+        assert_eq!(
+            state
+                .user_store
+                .campaign_role_for_user(campaign.id, guest.id)
+                .await
+                .unwrap(),
+            Some(GameRole::Player)
+        );
+
+        let legacy_room = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/token")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .header("cookie", &cookie)
+                    .body(Body::from(
+                        serde_json::json!({ "room": "dnd-table-1", "name": "Guest" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(legacy_room.status(), StatusCode::FORBIDDEN);
+
+        let invited_room = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/token")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .header("cookie", cookie)
+                    .body(Body::from(
+                        serde_json::json!({ "room": "invite-table", "name": "Guest" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(invited_room.status(), StatusCode::OK);
     }
 }

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -1,10 +1,11 @@
 use reqwest::Client;
 
-use crate::{config::AppConfig, users::UserStore};
+use crate::{config::AppConfig, invites::InviteStore, users::UserStore};
 
 #[derive(Debug, Clone)]
 pub(crate) struct AppState {
     pub(crate) http_client: Client,
     pub(crate) config: AppConfig,
+    pub(crate) invite_store: InviteStore,
     pub(crate) user_store: UserStore,
 }

--- a/backend/src/token.rs
+++ b/backend/src/token.rs
@@ -109,6 +109,18 @@ pub(crate) async fn mint_token(
             return Err(ApiError::RoomNotAllowed(req.room.clone()));
         }
         (campaign.room_slug, campaign_role)
+    } else if state
+        .invite_store
+        .is_user_invite_restricted(user.id)
+        .await
+        .map_err(|err| {
+            error!("invite access scope lookup failed: {err}");
+            ApiError::Internal
+        })?
+        && user.platform_role != PlatformRole::Admin
+        && user.game_role != GameRole::Gamemaster
+    {
+        return Err(ApiError::RoomNotAllowed(req.room.clone()));
     } else if let Some(allowed_rooms) = &state.config.allowed_rooms {
         if !allowed_rooms.contains(&req.room) {
             return Err(ApiError::RoomNotAllowed(req.room.clone()));

--- a/backend/src/users.rs
+++ b/backend/src/users.rs
@@ -15,6 +15,10 @@ pub struct UserStore {
 }
 
 impl UserStore {
+    pub(crate) fn sqlite_pool(&self) -> SqlitePool {
+        self.pool.clone()
+    }
+
     pub async fn connect(database_url: &str) -> Result<Self, StoreError> {
         ensure_sqlite_parent_dir(database_url).await?;
 
@@ -759,7 +763,7 @@ impl UserStore {
         Ok(count > 0)
     }
 
-    async fn find_campaign_by_id(
+    pub(crate) async fn find_campaign_by_id(
         &self,
         campaign_id: i64,
     ) -> Result<Option<CampaignPreset>, StoreError> {

--- a/docs/plans/2026-07-09_role-scoped-campaign-invites.md
+++ b/docs/plans/2026-07-09_role-scoped-campaign-invites.md
@@ -1,0 +1,27 @@
+# Role-scoped campaign invites
+
+## Outcome
+
+Add single-purpose player invite links for campaign presets. A bearer link may authenticate a new Google user, create player-only allowlist access, add a player seat to exactly one campaign, and never grant platform-admin or gamemaster authority.
+
+## Backend
+
+- Store only a SHA-256 token digest plus a short hint; return the bearer token once at creation.
+- Persist expiry, optional maximum uses, revocation, unique-user redemptions, and invite-created restricted users.
+- Keep redemption atomic and idempotent. New users receive `USER` / `PLAYER`; existing roles are preserved and campaign membership is never promoted.
+- Permit admins to manage all campaign invites and gamemasters only for campaigns they already manage.
+- Integrate invite redemption into Google callback and development login so unknown users can authenticate only through a valid invite.
+- Deny invite-created restricted users access to legacy non-campaign rooms.
+
+## Frontend
+
+- Extend each campaign card with an invite-slip panel for create, one-time copy/open, status, usage, expiry, and revoke.
+- Add `/invite/$token` as a thin route over an auth-aware invite landing feature.
+- Show explicit invalid, revoked, expired, exhausted, and successful redemption states.
+
+## Validation
+
+- Backend persistence, authorization, expiry, revocation, max-use, idempotency, and role tests.
+- Frontend invite-management and invite-landing unit tests.
+- Multi-context Playwright coverage for GM creation, unknown-user dev authentication/redemption, room entry, and revoked-link handling.
+- Repository lint, typecheck, unit tests, build, Rust fmt/clippy/tests/build, and headed Playwright CLI visual smoke test.

--- a/frontend/e2e/auth-admin.spec.ts
+++ b/frontend/e2e/auth-admin.spec.ts
@@ -83,3 +83,56 @@ test("gamemaster can open the campaign management console without platform admin
   await expect(page.getByRole("heading", { name: "Campaign tables" })).toBeVisible();
   await expect(page.getByTestId("campaign-create-form")).toBeVisible();
 });
+
+test("gamemaster invite link provisions a player and revoked links stay closed", async ({ browser }) => {
+  const stamp = Date.now();
+  const adminEmail = `gm@${E2E_EMAIL_DOMAIN}`;
+  const guestEmail = `invite.guest.${stamp}@${E2E_EMAIL_DOMAIN}`;
+  const roomSlug = `invite-table-${stamp}`;
+  const campaignName = `Invite Table ${stamp}`;
+  const adminContext = await browser.newContext();
+  const guestContext = await browser.newContext();
+  const revokedContext = await browser.newContext();
+  const adminPage = await adminContext.newPage();
+  const guestPage = await guestContext.newPage();
+  const revokedPage = await revokedContext.newPage();
+
+  try {
+    await adminPage.goto(devLoginUrl(adminEmail, "/campaigns", "GM"));
+    const campaignForm = adminPage.getByTestId("campaign-create-form");
+    await campaignForm.getByLabel("Display name").fill(campaignName);
+    await campaignForm.getByLabel("Room slug").fill(roomSlug);
+    await campaignForm.getByLabel(`Seat for ${adminEmail}`).selectOption("gm");
+    await campaignForm.getByRole("button", { name: "Create campaign" }).click();
+
+    const campaignCard = adminPage.getByTestId(/campaign-\d+/).filter({ hasText: campaignName });
+    await expect(campaignCard).toBeVisible();
+    const inviteForm = campaignCard.getByTestId("invite-create-form");
+    await inviteForm.getByLabel("Max uses").fill("1");
+    await inviteForm.getByRole("button", { name: "Create slip" }).click();
+    const firstLink = await campaignCard.getByLabel("New invite link").inputValue();
+    const firstPath = new URL(firstLink).pathname;
+
+    await guestPage.goto(firstPath);
+    await expect(guestPage.getByRole("heading", { name: "A place is set for you" })).toBeVisible();
+    await expect(guestPage.getByRole("link", { name: "Continue with Google" })).toBeVisible();
+    await guestPage.goto(devLoginUrl(guestEmail, firstPath, "Invite Guest"));
+    await expect(guestPage.getByTestId("invite-success")).toContainText(campaignName);
+    await guestPage.getByRole("link", { name: `Enter ${campaignName}` }).click();
+    await expect(guestPage.getByRole("heading", { name: `Room: ${roomSlug}` })).toBeVisible();
+
+    await inviteForm.getByRole("button", { name: "Create slip" }).click();
+    const newInviteLink = campaignCard.getByLabel("New invite link");
+    await expect(newInviteLink).not.toHaveValue(firstLink);
+    const secondLink = await newInviteLink.inputValue();
+    const secondPath = new URL(secondLink).pathname;
+    const newestInvite = campaignCard.getByTestId(/^invite-\d+$/).first();
+    await newestInvite.getByRole("button", { name: "Revoke" }).click();
+    await expect(newestInvite).toContainText("revoked");
+
+    await revokedPage.goto(secondPath);
+    await expect(revokedPage.getByText("This invitation was revoked by its gamemaster.")).toBeVisible();
+  } finally {
+    await Promise.all([adminContext.close(), guestContext.close(), revokedContext.close()]);
+  }
+});

--- a/frontend/src/features/campaigns/components/CampaignAdminPanel.tsx
+++ b/frontend/src/features/campaigns/components/CampaignAdminPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useManagedCampaigns } from "@/features/campaigns/hooks/useCampaigns";
 import type { CampaignDirectoryUser, CampaignInput, CampaignPreset } from "@/features/campaigns/types";
+import { InvitePanel } from "@/features/invites/components/InvitePanel";
 
 const EMPTY_CAMPAIGN: CampaignInput = {
   display_name: "",
@@ -130,6 +131,7 @@ function CampaignCard({
           {pending ? "Saving..." : "Save preset"}
         </button>
       </div>
+      <InvitePanel campaignArchived={campaign.is_archived} campaignId={campaign.id} />
     </article>
   );
 }

--- a/frontend/src/features/invites/components/InviteLanding.test.tsx
+++ b/frontend/src/features/invites/components/InviteLanding.test.tsx
@@ -1,0 +1,83 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { InviteLandingView } from "@/features/invites/components/InviteLanding";
+import type { PublicInvite } from "@/features/invites/types";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => <a href={to}>{children}</a>
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const ACTIVE_INVITE: PublicInvite = {
+  campaign_id: 7,
+  campaign_display_name: "The Ashen Ledger",
+  room_slug: "ashen-ledger",
+  role: "PLAYER",
+  status: "ACTIVE"
+};
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+function renderView(props: Partial<React.ComponentProps<typeof InviteLandingView>> = {}) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(
+      <InviteLandingView
+        invite={ACTIVE_INVITE}
+        loading={false}
+        redeeming={false}
+        redeemed={null}
+        token="secret-token"
+        {...props}
+      />
+    );
+  });
+}
+
+describe("InviteLandingView", () => {
+  it("offers auth with the invite path preserved", () => {
+    renderView();
+    const login = Array.from(container?.querySelectorAll("a") ?? []).find((node) =>
+      node.textContent?.includes("Continue with Google")
+    );
+    expect(login?.getAttribute("href")).toContain("next=%2Finvite%2Fsecret-token");
+    expect(container?.textContent).toContain("The Ashen Ledger");
+  });
+
+  it("shows a clear revoked state", () => {
+    renderView({ invite: { ...ACTIVE_INVITE, status: "REVOKED" } });
+    expect(container?.textContent).toContain("revoked by its gamemaster");
+    expect(container?.textContent).not.toContain("Continue with Google");
+  });
+
+  it("links a redeemed player directly to the campaign room", () => {
+    renderView({
+      redeemed: {
+        campaign_id: 7,
+        campaign_display_name: "The Ashen Ledger",
+        room_slug: "ashen-ledger"
+      },
+      user: {
+        id: 9,
+        email: "guest@example.com",
+        display_name: "Guest",
+        platform_role: "USER",
+        game_role: "PLAYER"
+      }
+    });
+    expect(container?.textContent).toContain("Seat confirmed");
+    expect(container?.textContent).toContain("Enter The Ashen Ledger");
+  });
+});

--- a/frontend/src/features/invites/components/InviteLanding.tsx
+++ b/frontend/src/features/invites/components/InviteLanding.tsx
@@ -1,0 +1,139 @@
+import { Link } from "@tanstack/react-router";
+import { buildGoogleLoginUrl } from "@/features/auth/lib/auth-api";
+import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
+import type { SessionUser } from "@/features/auth/types";
+import { useInviteRedemption } from "@/features/invites/hooks/useInvites";
+import type { InviteStatus, PublicInvite, RedeemedInvite } from "@/features/invites/types";
+
+export function InviteLanding({ token, callbackError }: { token: string; callbackError?: string }) {
+  const auth = useAuthSession();
+  const redemption = useInviteRedemption(token, auth.session.authenticated);
+  return (
+    <InviteLandingView
+      authError={auth.error}
+      callbackError={callbackError}
+      invite={redemption.invite}
+      inviteError={redemption.error}
+      loading={auth.isLoading || redemption.isLoading}
+      redeeming={redemption.isRedeeming}
+      redeemed={redemption.redeemed}
+      token={token}
+      user={auth.session.user}
+    />
+  );
+}
+
+export function InviteLandingView({
+  authError,
+  callbackError,
+  invite,
+  inviteError,
+  loading,
+  redeeming,
+  redeemed,
+  token,
+  user
+}: {
+  authError?: string | null;
+  callbackError?: string;
+  invite: PublicInvite | null;
+  inviteError?: string | null;
+  loading: boolean;
+  redeeming: boolean;
+  redeemed: RedeemedInvite | null;
+  token: string;
+  user?: SessionUser;
+}) {
+  const status = callbackError ? callbackStatus(callbackError) : invite?.status;
+  const failure = authError ?? inviteError;
+  const loginPath = `/invite/${encodeURIComponent(token)}`;
+
+  return (
+    <main className="relative flex min-h-screen items-center overflow-hidden bg-[var(--c-void)] px-6 py-12">
+      <div className="pointer-events-none absolute inset-0 opacity-30 [background-image:radial-gradient(circle_at_20%_20%,rgba(182,137,69,0.18),transparent_32%),linear-gradient(115deg,transparent_48%,rgba(255,255,255,0.025)_49%,transparent_50%)]" />
+      <section className="relative mx-auto w-full max-w-2xl border border-[var(--c-rule)] bg-[linear-gradient(145deg,rgba(20,26,31,0.98),rgba(7,8,10,0.98))] p-7 shadow-[0_28px_100px_rgba(0,0,0,0.55)] md:p-10">
+        <div className="border-b border-dashed border-[var(--c-rule)] pb-7">
+          <p className="text-[9px] uppercase tracking-[0.22em] text-[var(--c-gold)]">Bearer invitation · player seat</p>
+          <h1 className="display-face mt-4 text-4xl text-[var(--c-text-warm)]">A place is set for you</h1>
+          <p className="mt-4 max-w-xl text-sm leading-6 text-[var(--c-text-dim)]">
+            This seal opens one campaign table. Sign in with the Google account you want attached to the seat.
+          </p>
+        </div>
+
+        {loading ? <InviteMessage eyebrow="Checking the seal" title="Reading the invitation..." /> : null}
+        {!loading && redeemed ? (
+          <div className="mt-8" data-testid="invite-success">
+            <InviteMessage eyebrow="Seat confirmed" title={`Welcome to ${redeemed.campaign_display_name}`} />
+            <p className="mt-3 text-sm text-[var(--c-text-dim)]">Your account has player access to this campaign.</p>
+            <Link
+              className="chip mt-7 w-full justify-center py-3 text-xs"
+              params={{ room: redeemed.room_slug }}
+              search={{ name: fallbackName(user) }}
+              to="/room/$room"
+            >
+              Enter {redeemed.campaign_display_name}
+            </Link>
+          </div>
+        ) : null}
+        {!loading && !redeemed && redeeming ? <InviteMessage eyebrow="Accepting" title="Adding your player seat..." /> : null}
+        {!loading && !redeemed && !redeeming && failure ? (
+          <InviteMessage eyebrow="The seal did not open" title={failure} tone="error" />
+        ) : null}
+        {!loading && !redeemed && !redeeming && !failure && !user && status === "ACTIVE" && invite ? (
+          <div className="mt-8" data-testid="invite-sign-in">
+            <InviteMessage eyebrow="Invitation verified" title={invite.campaign_display_name} />
+            <p className="mt-3 text-sm text-[var(--c-text-dim)]">{expiryCopy(invite.expires_at)}</p>
+            <a className="chip mt-7 w-full justify-center py-3 text-xs" href={buildGoogleLoginUrl(loginPath)}>
+              Continue with Google
+            </a>
+          </div>
+        ) : null}
+        {!loading && !redeemed && !redeeming && !failure && !user && status && status !== "ACTIVE" ? (
+          <InviteMessage eyebrow="Invitation unavailable" title={statusMessage(status)} tone="error" />
+        ) : null}
+        <div className="mt-9 flex items-center justify-between gap-4 border-t border-[var(--c-rule)] pt-5 text-[10px] text-[var(--c-text-faint)]">
+          <span className="font-mono">seal {token.slice(0, 8)}…</span>
+          <Link className="act" to="/">Return home</Link>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function InviteMessage({ eyebrow, title, tone = "normal" }: { eyebrow: string; title: string; tone?: "normal" | "error" }) {
+  return (
+    <div className="mt-8">
+      <p className={`text-[9px] uppercase tracking-[0.18em] ${tone === "error" ? "text-[var(--c-ember)]" : "text-[var(--c-emerald)]"}`}>{eyebrow}</p>
+      <h2 className={`display-face mt-3 text-2xl ${tone === "error" ? "text-[var(--c-ember)]" : "text-[var(--c-text-warm)]"}`}>{title}</h2>
+    </div>
+  );
+}
+
+function callbackStatus(value: string): InviteStatus | undefined {
+  const statuses: Record<string, InviteStatus> = {
+    revoked: "REVOKED",
+    expired: "EXPIRED",
+    exhausted: "EXHAUSTED",
+    archived: "ARCHIVED"
+  };
+  return statuses[value];
+}
+
+function statusMessage(status: InviteStatus) {
+  const messages: Record<InviteStatus, string> = {
+    ACTIVE: "This invitation is ready.",
+    REVOKED: "This invitation was revoked by its gamemaster.",
+    EXPIRED: "This invitation has expired.",
+    EXHAUSTED: "This invitation has already filled every available seat.",
+    ARCHIVED: "This campaign is archived."
+  };
+  return messages[status];
+}
+
+function expiryCopy(expiresAt?: number) {
+  return expiresAt ? `This invitation expires ${new Date(expiresAt * 1000).toLocaleString()}.` : "This invitation has no expiry.";
+}
+
+function fallbackName(user?: SessionUser) {
+  return user?.display_name?.trim() || user?.email.split("@")[0] || "Player";
+}

--- a/frontend/src/features/invites/components/InvitePanel.test.tsx
+++ b/frontend/src/features/invites/components/InvitePanel.test.tsx
@@ -1,0 +1,80 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { InvitePanel } from "@/features/invites/components/InvitePanel";
+
+const { createInvite, revokeInvite } = vi.hoisted(() => ({
+  createInvite: vi.fn(),
+  revokeInvite: vi.fn()
+}));
+
+vi.mock("@/features/invites/hooks/useInvites", () => ({
+  useCampaignInvites: () => ({
+    create: createInvite,
+    error: null,
+    invites: [
+      {
+        id: 4,
+        campaign_id: 7,
+        campaign_display_name: "The Ashen Ledger",
+        room_slug: "ashen-ledger",
+        token_hint: "abcdefgh",
+        role: "PLAYER",
+        max_uses: 2,
+        use_count: 1,
+        status: "ACTIVE",
+        created_at: "2026-07-09"
+      }
+    ],
+    isLoading: false,
+    reload: vi.fn(),
+    revoke: revokeInvite
+  })
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+  createInvite.mockReset();
+  revokeInvite.mockReset();
+});
+
+describe("InvitePanel", () => {
+  it("creates a player-only invite and reveals its one-time link", async () => {
+    createInvite.mockResolvedValue({
+      invite: { id: 5 },
+      token: "secret",
+      path: "/invite/secret"
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root?.render(<InvitePanel campaignArchived={false} campaignId={7} />));
+
+    const button = Array.from(container.querySelectorAll("button")).find((node) => node.textContent === "Create slip");
+    await act(async () => button?.click());
+
+    expect(createInvite).toHaveBeenCalledWith({ role: "PLAYER", max_uses: 1 });
+    expect((container.querySelector("[aria-label='New invite link']") as HTMLInputElement).value).toContain("/invite/secret");
+  });
+
+  it("lists usage and revokes an active invite", async () => {
+    revokeInvite.mockResolvedValue(undefined);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root?.render(<InvitePanel campaignArchived={false} campaignId={7} />));
+
+    expect(container.textContent).toContain("1 of 2 used");
+    const revoke = Array.from(container.querySelectorAll("button")).find((node) => node.textContent === "Revoke");
+    await act(async () => revoke?.click());
+    expect(revokeInvite).toHaveBeenCalledWith(4);
+  });
+});

--- a/frontend/src/features/invites/components/InvitePanel.tsx
+++ b/frontend/src/features/invites/components/InvitePanel.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import { useCampaignInvites } from "@/features/invites/hooks/useInvites";
+import type { CampaignInvite, InviteInput } from "@/features/invites/types";
+
+export function InvitePanel({ campaignId, campaignArchived }: { campaignId: number; campaignArchived: boolean }) {
+  const inviteState = useCampaignInvites(campaignId);
+  const [expiresAt, setExpiresAt] = useState("");
+  const [maxUses, setMaxUses] = useState("1");
+  const [createdLink, setCreatedLink] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [copyLabel, setCopyLabel] = useState("Copy link");
+
+  const create = async () => {
+    setPending(true);
+    setActionError(null);
+    try {
+      const input: InviteInput = {
+        role: "PLAYER",
+        expires_at: expiresAt ? Math.floor(new Date(expiresAt).getTime() / 1000) : undefined,
+        max_uses: maxUses ? Number(maxUses) : undefined
+      };
+      const created = await inviteState.create(input);
+      const origin = typeof window === "undefined" ? "" : window.location.origin;
+      setCreatedLink(`${origin}${created.path}`);
+      setCopyLabel("Copy link");
+    } catch (value) {
+      setActionError(value instanceof Error ? value.message : "Failed to create invite");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const copy = async () => {
+    if (!createdLink) return;
+    try {
+      await navigator.clipboard.writeText(createdLink);
+      setCopyLabel("Copied");
+    } catch {
+      setCopyLabel("Select and copy");
+    }
+  };
+
+  const revoke = async (inviteId: number) => {
+    setActionError(null);
+    try {
+      await inviteState.revoke(inviteId);
+    } catch (value) {
+      setActionError(value instanceof Error ? value.message : "Failed to revoke invite");
+    }
+  };
+
+  return (
+    <section className="mt-7 border-t border-dashed border-[var(--c-rule)] pt-6" data-testid={`invite-panel-${campaignId}`}>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-[9px] uppercase tracking-[0.18em] text-[var(--c-gold)]">Admit one more traveler</p>
+          <h4 className="display-face mt-2 text-lg text-[var(--c-text-warm)]">Player invite slips</h4>
+          <p className="mt-2 max-w-xl text-xs leading-5 text-[var(--c-text-dim)]">
+            Each bearer link grants only a player seat at this table. The secret is shown once.
+          </p>
+        </div>
+        <span className="border border-[var(--c-rule)] px-2 py-1 font-mono text-[9px] uppercase tracking-[0.12em] text-[var(--c-text-faint)]">
+          Player only
+        </span>
+      </div>
+
+      {!campaignArchived ? (
+        <div className="mt-5 grid gap-3 border border-[var(--c-rule)] bg-[rgba(0,0,0,0.16)] p-4 sm:grid-cols-[1fr_110px_auto] sm:items-end" data-testid="invite-create-form">
+          <label className="text-[9px] uppercase tracking-[0.08em] text-[var(--c-text-dim)]">
+            Expires (optional)
+            <input className="field mt-2" min={localDateTimeMinimum()} onChange={(event) => setExpiresAt(event.target.value)} type="datetime-local" value={expiresAt} />
+          </label>
+          <label className="text-[9px] uppercase tracking-[0.08em] text-[var(--c-text-dim)]">
+            Max uses
+            <input className="field mt-2" max={1000} min={1} onChange={(event) => setMaxUses(event.target.value)} type="number" value={maxUses} />
+          </label>
+          <button className="act act--gold h-[42px] justify-center" disabled={pending} onClick={() => void create()} type="button">
+            {pending ? "Sealing..." : "Create slip"}
+          </button>
+        </div>
+      ) : null}
+
+      {createdLink ? (
+        <div className="mt-4 border-l-2 border-[var(--c-gold)] bg-[rgba(182,137,69,0.08)] p-4" data-testid="created-invite-slip">
+          <p className="text-[9px] uppercase tracking-[0.14em] text-[var(--c-gold)]">Fresh seal · copy now</p>
+          <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+            <input aria-label="New invite link" className="field min-w-0 flex-1 font-mono text-[11px]" readOnly value={createdLink} />
+            <button className="act" onClick={() => void copy()} type="button">{copyLabel}</button>
+            <a className="act" href={createdLink}>Open invite</a>
+          </div>
+        </div>
+      ) : null}
+
+      {actionError || inviteState.error ? (
+        <p className="mt-4 text-xs text-[var(--c-ember)]">{actionError ?? inviteState.error}</p>
+      ) : null}
+      {inviteState.isLoading ? <p className="mt-4 text-xs text-[var(--c-text-faint)]">Checking issued slips...</p> : null}
+      <div className="mt-4 grid gap-2">
+        {inviteState.invites.map((invite) => (
+          <InviteRow invite={invite} key={invite.id} onRevoke={revoke} />
+        ))}
+        {!inviteState.isLoading && inviteState.invites.length === 0 ? (
+          <p className="border border-dashed border-[var(--c-rule)] px-4 py-3 text-xs text-[var(--c-text-faint)]">No invite slips issued.</p>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function InviteRow({ invite, onRevoke }: { invite: CampaignInvite; onRevoke: (id: number) => Promise<void> }) {
+  const [pending, setPending] = useState(false);
+  return (
+    <div className="grid gap-3 border border-[var(--c-rule)] px-4 py-3 sm:grid-cols-[1fr_auto_auto] sm:items-center" data-testid={`invite-${invite.id}`}>
+      <div>
+        <p className="font-mono text-[11px] text-[var(--c-text-dim)]">seal {invite.token_hint}…</p>
+        <p className="mt-1 text-[10px] text-[var(--c-text-faint)]">
+          {usageLabel(invite)} · {expiryLabel(invite.expires_at)}
+        </p>
+      </div>
+      <span className={`text-[9px] uppercase tracking-[0.14em] ${invite.status === "ACTIVE" ? "text-[var(--c-emerald)]" : "text-[var(--c-ember)]"}`}>
+        {invite.status.toLowerCase()}
+      </span>
+      {invite.status === "ACTIVE" ? (
+        <button
+          className="act act--hot"
+          disabled={pending}
+          onClick={() => {
+            setPending(true);
+            void onRevoke(invite.id).finally(() => setPending(false));
+          }}
+          type="button"
+        >
+          {pending ? "Revoking..." : "Revoke"}
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function usageLabel(invite: CampaignInvite) {
+  return invite.max_uses ? `${invite.use_count} of ${invite.max_uses} used` : `${invite.use_count} used`;
+}
+
+function expiryLabel(expiresAt?: number) {
+  return expiresAt ? `expires ${new Date(expiresAt * 1000).toLocaleString()}` : "no expiry";
+}
+
+function localDateTimeMinimum() {
+  const date = new Date(Date.now() + 60_000);
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 16);
+}

--- a/frontend/src/features/invites/hooks/useInvites.ts
+++ b/frontend/src/features/invites/hooks/useInvites.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  createCampaignInvite,
+  fetchCampaignInvites,
+  fetchPublicInvite,
+  redeemInvite,
+  revokeCampaignInvite
+} from "@/features/invites/lib/invite-api";
+import type { CreatedInvite, InviteInput, PublicInvite, RedeemedInvite } from "@/features/invites/types";
+
+export function useCampaignInvites(campaignId: number) {
+  const [invites, setInvites] = useState<Awaited<ReturnType<typeof fetchCampaignInvites>>>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      setInvites(await fetchCampaignInvites(campaignId));
+    } catch (value) {
+      setError(value instanceof Error ? value.message : "Failed to load invite links");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [campaignId]);
+
+  useEffect(() => void reload(), [reload]);
+
+  const create = useCallback(async (input: InviteInput): Promise<CreatedInvite> => {
+    const created = await createCampaignInvite(campaignId, input);
+    setInvites((current) => [created.invite, ...current]);
+    return created;
+  }, [campaignId]);
+
+  const revoke = useCallback(async (inviteId: number) => {
+    await revokeCampaignInvite(campaignId, inviteId);
+    setInvites((current) =>
+      current.map((invite) => invite.id === inviteId ? { ...invite, status: "REVOKED" } : invite)
+    );
+  }, [campaignId]);
+
+  return { create, error, invites, isLoading, reload, revoke };
+}
+
+export function useInviteRedemption(token: string, authenticated: boolean) {
+  const [invite, setInvite] = useState<PublicInvite | null>(null);
+  const [redeemed, setRedeemed] = useState<RedeemedInvite | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRedeeming, setIsRedeeming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const attemptedToken = useRef<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setIsLoading(true);
+    setError(null);
+    void fetchPublicInvite(token)
+      .then((value) => active && setInvite(value))
+      .catch((value: unknown) => active && setError(value instanceof Error ? value.message : "Invite link is invalid"))
+      .finally(() => active && setIsLoading(false));
+    return () => { active = false; };
+  }, [token]);
+
+  useEffect(() => {
+    if (!authenticated) {
+      attemptedToken.current = null;
+      return;
+    }
+    if (!invite || redeemed || isRedeeming || attemptedToken.current === token) return;
+    attemptedToken.current = token;
+    setIsRedeeming(true);
+    setError(null);
+    void redeemInvite(token)
+      .then(setRedeemed)
+      .catch((value: unknown) => setError(value instanceof Error ? value.message : "Invite could not be redeemed"))
+      .finally(() => setIsRedeeming(false));
+  }, [authenticated, invite, isRedeeming, redeemed, token]);
+
+  return { error, invite, isLoading, isRedeeming, redeemed };
+}

--- a/frontend/src/features/invites/lib/invite-api.ts
+++ b/frontend/src/features/invites/lib/invite-api.ts
@@ -1,0 +1,54 @@
+import type {
+  CampaignInvite,
+  CampaignInvitesResponse,
+  CreatedInvite,
+  InviteInput,
+  PublicInvite,
+  RedeemedInvite
+} from "@/features/invites/types";
+
+type ApiErrorPayload = { error?: { message?: string } };
+
+async function readJson<T>(response: Response): Promise<T> {
+  if (response.ok) return (await response.json()) as T;
+  const body = (await response.json().catch(() => ({}))) as ApiErrorPayload;
+  throw new Error(body.error?.message ?? "Invite request failed");
+}
+
+export async function fetchCampaignInvites(campaignId: number): Promise<CampaignInvite[]> {
+  const response = await fetch(`/api/v1/campaigns/manage/${campaignId}/invites`, {
+    credentials: "include"
+  });
+  return (await readJson<CampaignInvitesResponse>(response)).invites;
+}
+
+export async function createCampaignInvite(campaignId: number, input: InviteInput): Promise<CreatedInvite> {
+  const response = await fetch(`/api/v1/campaigns/manage/${campaignId}/invites`, {
+    credentials: "include",
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input)
+  });
+  return readJson<CreatedInvite>(response);
+}
+
+export async function revokeCampaignInvite(campaignId: number, inviteId: number): Promise<void> {
+  const response = await fetch(`/api/v1/campaigns/manage/${campaignId}/invites/${inviteId}`, {
+    credentials: "include",
+    method: "DELETE"
+  });
+  if (!response.ok) await readJson<never>(response);
+}
+
+export async function fetchPublicInvite(token: string): Promise<PublicInvite> {
+  const response = await fetch(`/api/v1/invites/${encodeURIComponent(token)}`);
+  return readJson<PublicInvite>(response);
+}
+
+export async function redeemInvite(token: string): Promise<RedeemedInvite> {
+  const response = await fetch(`/api/v1/invites/${encodeURIComponent(token)}/redeem`, {
+    credentials: "include",
+    method: "POST"
+  });
+  return readJson<RedeemedInvite>(response);
+}

--- a/frontend/src/features/invites/types.ts
+++ b/frontend/src/features/invites/types.ts
@@ -1,0 +1,42 @@
+export type InviteRole = "PLAYER";
+export type InviteStatus = "ACTIVE" | "REVOKED" | "EXPIRED" | "EXHAUSTED" | "ARCHIVED";
+
+export type CampaignInvite = {
+  id: number;
+  campaign_id: number;
+  campaign_display_name: string;
+  room_slug: string;
+  token_hint: string;
+  role: InviteRole;
+  expires_at?: number;
+  max_uses?: number;
+  use_count: number;
+  status: InviteStatus;
+  revoked_at?: string;
+  created_at: string;
+};
+
+export type PublicInvite = Pick<
+  CampaignInvite,
+  "campaign_id" | "campaign_display_name" | "room_slug" | "role" | "expires_at" | "status"
+>;
+
+export type InviteInput = {
+  role: InviteRole;
+  expires_at?: number;
+  max_uses?: number;
+};
+
+export type CreatedInvite = {
+  invite: CampaignInvite;
+  token: string;
+  path: string;
+};
+
+export type RedeemedInvite = {
+  campaign_id: number;
+  campaign_display_name: string;
+  room_slug: string;
+};
+
+export type CampaignInvitesResponse = { invites: CampaignInvite[] };

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as CampaignsRouteImport } from './routes/campaigns'
 import { Route as AdminRouteImport } from './routes/admin'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as RoomRoomRouteImport } from './routes/room.$room'
+import { Route as InviteTokenRouteImport } from './routes/invite.$token'
 import { Route as AuthUnauthorizedRouteImport } from './routes/auth.unauthorized'
 
 const CampaignsRoute = CampaignsRouteImport.update({
@@ -35,6 +36,11 @@ const RoomRoomRoute = RoomRoomRouteImport.update({
   path: '/room/$room',
   getParentRoute: () => rootRouteImport,
 } as any)
+const InviteTokenRoute = InviteTokenRouteImport.update({
+  id: '/invite/$token',
+  path: '/invite/$token',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthUnauthorizedRoute = AuthUnauthorizedRouteImport.update({
   id: '/auth/unauthorized',
   path: '/auth/unauthorized',
@@ -46,6 +52,7 @@ export interface FileRoutesByFullPath {
   '/admin': typeof AdminRoute
   '/campaigns': typeof CampaignsRoute
   '/auth/unauthorized': typeof AuthUnauthorizedRoute
+  '/invite/$token': typeof InviteTokenRoute
   '/room/$room': typeof RoomRoomRoute
 }
 export interface FileRoutesByTo {
@@ -53,6 +60,7 @@ export interface FileRoutesByTo {
   '/admin': typeof AdminRoute
   '/campaigns': typeof CampaignsRoute
   '/auth/unauthorized': typeof AuthUnauthorizedRoute
+  '/invite/$token': typeof InviteTokenRoute
   '/room/$room': typeof RoomRoomRoute
 }
 export interface FileRoutesById {
@@ -61,6 +69,7 @@ export interface FileRoutesById {
   '/admin': typeof AdminRoute
   '/campaigns': typeof CampaignsRoute
   '/auth/unauthorized': typeof AuthUnauthorizedRoute
+  '/invite/$token': typeof InviteTokenRoute
   '/room/$room': typeof RoomRoomRoute
 }
 export interface FileRouteTypes {
@@ -70,15 +79,23 @@ export interface FileRouteTypes {
     | '/admin'
     | '/campaigns'
     | '/auth/unauthorized'
+    | '/invite/$token'
     | '/room/$room'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/admin' | '/campaigns' | '/auth/unauthorized' | '/room/$room'
+  to:
+    | '/'
+    | '/admin'
+    | '/campaigns'
+    | '/auth/unauthorized'
+    | '/invite/$token'
+    | '/room/$room'
   id:
     | '__root__'
     | '/'
     | '/admin'
     | '/campaigns'
     | '/auth/unauthorized'
+    | '/invite/$token'
     | '/room/$room'
   fileRoutesById: FileRoutesById
 }
@@ -87,6 +104,7 @@ export interface RootRouteChildren {
   AdminRoute: typeof AdminRoute
   CampaignsRoute: typeof CampaignsRoute
   AuthUnauthorizedRoute: typeof AuthUnauthorizedRoute
+  InviteTokenRoute: typeof InviteTokenRoute
   RoomRoomRoute: typeof RoomRoomRoute
 }
 
@@ -120,6 +138,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RoomRoomRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/invite/$token': {
+      id: '/invite/$token'
+      path: '/invite/$token'
+      fullPath: '/invite/$token'
+      preLoaderRoute: typeof InviteTokenRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/auth/unauthorized': {
       id: '/auth/unauthorized'
       path: '/auth/unauthorized'
@@ -135,6 +160,7 @@ const rootRouteChildren: RootRouteChildren = {
   AdminRoute: AdminRoute,
   CampaignsRoute: CampaignsRoute,
   AuthUnauthorizedRoute: AuthUnauthorizedRoute,
+  InviteTokenRoute: InviteTokenRoute,
   RoomRoomRoute: RoomRoomRoute,
 }
 export const routeTree = rootRouteImport

--- a/frontend/src/routes/invite.$token.tsx
+++ b/frontend/src/routes/invite.$token.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { InviteLanding } from "@/features/invites/components/InviteLanding";
+
+type InviteSearch = { error?: string };
+
+export const Route = createFileRoute("/invite/$token")({
+  validateSearch: (search: Record<string, unknown>): InviteSearch => ({
+    error: typeof search.error === "string" ? search.error : undefined
+  }),
+  component: InvitePage
+});
+
+function InvitePage() {
+  const { token } = Route.useParams();
+  const { error } = Route.useSearch();
+  return <InviteLanding callbackError={error} token={token} />;
+}


### PR DESCRIPTION
## Summary
- add persistent, hashed player invite links with expiry, max-use, revocation, and GM/admin ownership checks
- redeem invites through Google auth to provision campaign-scoped player access without admin or gamemaster escalation
- add campaign invite management and a clear invite landing experience

## Validation
- `cargo test --manifest-path backend/Cargo.toml`
- `cargo clippy --manifest-path backend/Cargo.toml --all-targets -- -D warnings`
- `pnpm --filter frontend lint`
- `pnpm --filter frontend typecheck`
- `pnpm --filter frontend test`
- `pnpm --filter frontend build`
- Playwright: 11/11 multi-session scenarios
- interactive Playwright visual review

Closes #131