### PR TITLE
fix(dependencies): patch URI and expansion advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
       "undici": "7.28.0",
       "flatted": "3.4.2",
       "picomatch@^4.0.0": "4.0.4",
+      "brace-expansion": "5.0.8",
       "fast-uri": "3.1.4",
       "js-yaml": "4.3.0",
       "h3-v2": "npm:h3@2.0.1-rc.20",
@@ -64,6 +65,13 @@
         ],
         "reference": "https://github.com/fastify/fast-uri/releases/tag/v3.1.4",
         "note": "Pinned to 3.1.4 to keep the URI parsing fixes for the 2026 fast-uri advisories in place. Remove once every transitive consumer accepts >=3.1.4 without an override and upstream no longer needs the pin."
+      },
+      "brace-expansion": {
+        "mitigates": [
+          "GHSA-mh99-v99m-4gvg"
+        ],
+        "reference": "https://github.com/advisories/GHSA-mh99-v99m-4gvg",
+        "note": "Pins all transitive consumers to 5.0.8 because the advisory range includes every older release. Remove once minimatch and other consumers resolve a patched brace-expansion without an override."
       },
       "js-yaml": {
         "mitigates": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "undici": "7.28.0",
       "flatted": "3.4.2",
       "picomatch@^4.0.0": "4.0.4",
-      "fast-uri": "3.1.2",
+      "fast-uri": "3.1.4",
       "js-yaml": "4.3.0",
       "h3-v2": "npm:h3@2.0.1-rc.20",
       "@tanstack/react-start": "1.168.32",
@@ -56,10 +56,14 @@
         "mitigates": [
           "GHSA-q3j6-qgpj-74h6",
           "GHSA-v39h-62p7-jpjc",
-          "CVE-2026-6322"
+          "CVE-2026-6322",
+          "GHSA-4c8g-83qw-93j6",
+          "CVE-2026-13676",
+          "GHSA-v2hh-gcrm-f6hx",
+          "CVE-2026-16221"
         ],
-        "reference": "https://github.com/fastify/fast-uri/security/advisories/GHSA-v39h-62p7-jpjc",
-        "note": "Pinned to 3.1.2 to keep the URI parsing fixes for the 2026 fast-uri advisories in place. Remove once every transitive consumer accepts >=3.1.2 without an override and upstream no longer needs the pin."
+        "reference": "https://github.com/fastify/fast-uri/releases/tag/v3.1.4",
+        "note": "Pinned to 3.1.4 to keep the URI parsing fixes for the 2026 fast-uri advisories in place. Remove once every transitive consumer accepts >=3.1.4 without an override and upstream no longer needs the pin."
       },
       "js-yaml": {
         "mitigates": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   undici: 7.28.0
   flatted: 3.4.2
   picomatch@^4.0.0: 4.0.4
-  fast-uri: 3.1.2
+  fast-uri: 3.1.4
   js-yaml: 4.3.0
   h3-v2: npm:h3@2.0.1-rc.20
   '@tanstack/react-start': 1.168.32
@@ -1227,8 +1227,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3036,7 +3036,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3346,7 +3346,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   undici: 7.28.0
   flatted: 3.4.2
   picomatch@^4.0.0: 4.0.4
+  brace-expansion: 5.0.8
   fast-uri: 3.1.4
   js-yaml: 4.3.0
   h3-v2: npm:h3@2.0.1-rc.20
@@ -959,9 +960,6 @@ packages:
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -978,12 +976,9 @@ packages:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.6:
     resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
@@ -1051,9 +1046,6 @@ packages:
   compression@1.8.1:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   content-disposition@0.5.2:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
@@ -3075,8 +3067,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.44: {}
@@ -3096,12 +3086,7 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3169,8 +3154,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  concat-map@0.0.1: {}
 
   content-disposition@0.5.2: {}
 
@@ -3602,11 +3585,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary

- update the reviewed `fast-uri` override from 3.1.2 to 3.1.4
- pin `brace-expansion` to 5.0.8 after the recovered audit endpoint exposed the newly published DoS advisory
- regenerate the lockfile with the expected security resolutions and record the covered advisories in dependency review notes

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm audit --audit-level high` (no known vulnerabilities)
- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `corepack pnpm test` (104 frontend tests and 45 backend tests)
- `corepack pnpm --filter frontend build`
- `corepack pnpm --filter infrastructure build`
- `git diff --check`

Fixes #219
Fixes #221


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `fast-uri` dependency override to version **3.1.4**.
  * Refreshed related security advisory and maintenance metadata to align with the new pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->