### PR TITLE
build(deps): update rand to 0.8.6

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1131,7 +1131,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -1296,7 +1296,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1590,9 +1590,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2175,7 +2175,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -2213,7 +2213,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2 0.10.9",


### PR DESCRIPTION
## Summary
- update the transitive backend `rand` lockfile entry from 0.8.5 to 0.8.6
- clear Dependabot alert #1 / `GHSA-cq8v-f236-94qc` without changing manifests or application behavior

## Validation
- `cargo fmt --manifest-path backend/Cargo.toml -- --check`
- `cargo clippy --manifest-path backend/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path backend/Cargo.toml --all-targets --all-features` (47 passed)
- `cargo build --manifest-path backend/Cargo.toml --locked`
- `cargo audit --file backend/Cargo.lock` (rand advisory removed; existing allowed `anyhow` warning and yanked `spin` warning remain)

Fixes #240
